### PR TITLE
Add History Bar Component and Historical Spot Fetching

### DIFF
--- a/backend/api/src/api/main.py
+++ b/backend/api/src/api/main.py
@@ -413,6 +413,24 @@ def download_catserver():
     )
 
 
+@app.get("/history")
+async def spot_history(start_time: int, end_time: int):
+    if end_time <= start_time:
+        raise HTTPException(status_code=400, detail="end_time must be greater than start_time")
+    if end_time - start_time > 86400:
+        raise HTTPException(status_code=400, detail="time range cannot exceed 24 hours")
+
+    async with async_session() as session:
+        query = (
+            select(HolySpot)
+            .where(HolySpot.timestamp >= start_time)
+            .where(HolySpot.timestamp <= end_time)
+            .order_by(HolySpot.timestamp)
+        )
+        spots = cleanup_spots((await session.execute(query)).scalars())
+        return {"spots": spots}
+
+
 @app.get("/health")
 async def health():
     return {"status": "ok"}

--- a/ui/src/components/MainContainer.jsx
+++ b/ui/src/components/MainContainer.jsx
@@ -295,7 +295,10 @@ function MainContent({
 function MainContainer() {
     const [history_start, set_history_start] = useState(null);
     const [history_end, set_history_end] = useState(null);
-    const [window_size_ms, set_window_size_ms] = useState(15 * 60_000);
+    const [window_size_ms, set_window_size_ms] = useLocalStorage(
+        "history-window-size",
+        15 * 60_000,
+    );
 
     return (
         <SpotDataProvider

--- a/ui/src/components/MainContainer.jsx
+++ b/ui/src/components/MainContainer.jsx
@@ -6,6 +6,7 @@ import UnsupportedVersion from "@/components/UnsupportedVersion.jsx";
 import LeftColumn from "@/components/LeftColumn.jsx";
 import SidePanel from "@/components/SidePanel.jsx";
 import Tabs from "@/components/ui/Tabs.jsx";
+import HistoryBar from "@/components/history/HistoryBar.jsx";
 import Maidenhead from "maidenhead";
 import {
     use_object_local_storage,
@@ -13,7 +14,7 @@ import {
     get_max_radius,
     get_spots_center,
 } from "@/utils.js";
-import { useSpotData } from "@/hooks/useSpotData";
+import { useSpotData, SpotDataProvider } from "@/hooks/useSpotData";
 import { useSpotInteraction } from "@/hooks/useSpotInteraction";
 import { useColors } from "@/hooks/useColors";
 import use_radio from "@/hooks/useRadio";
@@ -25,7 +26,14 @@ import { useLocalStorage, useMediaQuery } from "@uidotdev/usehooks";
 const AUTO_RADIUS_PADDING_KM = 1000;
 const AUTO_RADIUS_RECENTER_ENABLED = false;
 
-function MainContainer() {
+function MainContent({
+    history_start,
+    history_end,
+    set_history_start,
+    set_history_end,
+    window_size_ms,
+    set_window_size_ms,
+}) {
     const { dev_mode, set_dev_mode, colors } = useColors();
 
     useEffect(() => {
@@ -169,6 +177,19 @@ function MainContainer() {
     }
 
     const is_md_device = useMediaQuery("only screen and (max-width : 768px)");
+    const is_history_mode = !!(history_start && history_end);
+
+    function toggle_history() {
+        if (is_history_mode) {
+            set_history_start(null);
+            set_history_end(null);
+        } else {
+            const end = new Date();
+            const start = new Date(end.getTime() - window_size_ms);
+            set_history_start(start);
+            set_history_end(end);
+        }
+    }
 
     const map = (
         <div
@@ -185,6 +206,8 @@ function MainContainer() {
                 is_map_fullscreen={is_map_fullscreen}
                 toggle_map_fullscreen={toggle_map_fullscreen}
                 is_mobile={is_md_device}
+                is_history_mode={is_history_mode}
+                toggle_history={toggle_history}
             />
             <CanvasMap
                 map_controls={map_controls}
@@ -218,42 +241,77 @@ function MainContainer() {
                 set_toggled_ui={set_toggled_ui}
                 dev_mode={dev_mode}
             />
-            <div className="flex relative h-[calc(100%-4rem)]">
-                <LeftColumn toggled_ui={toggled_ui} />
-                {is_md_device ? (
-                    <Tabs
-                        local_storage_name="mobile_tab"
-                        tabs={[
-                            {
-                                label: "Map",
-                                content: map,
-                                icon: "M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m7.5-6.923c-.67.204-1.335.82-1.887 1.855A8 8 0 0 0 5.145 4H7.5zM4.09 4a9.3 9.3 0 0 1 .64-1.539 7 7 0 0 1 .597-.933A7.03 7.03 0 0 0 2.255 4zm-.582 3.5c.03-.877.138-1.718.312-2.5H1.674a7 7 0 0 0-.656 2.5zM4.847 5a12.5 12.5 0 0 0-.338 2.5H7.5V5zM8.5 5v2.5h2.99a12.5 12.5 0 0 0-.337-2.5zM4.51 8.5a12.5 12.5 0 0 0 .337 2.5H7.5V8.5zm3.99 0V11h2.653c.187-.765.306-1.608.338-2.5zM5.145 12q.208.58.468 1.068c.552 1.035 1.218 1.65 1.887 1.855V12zm.182 2.472a7 7 0 0 1-.597-.933A9.3 9.3 0 0 1 4.09 12H2.255a7 7 0 0 0 3.072 2.472M3.82 11a13.7 13.7 0 0 1-.312-2.5h-2.49c.062.89.291 1.733.656 2.5zm6.853 3.472A7 7 0 0 0 13.745 12H11.91a9.3 9.3 0 0 1-.64 1.539 7 7 0 0 1-.597.933M8.5 12v2.923c.67-.204 1.335-.82 1.887-1.855q.26-.487.468-1.068zm3.68-1h2.146c.365-.767.594-1.61.656-2.5h-2.49a13.7 13.7 0 0 1-.312 2.5m2.802-3.5a7 7 0 0 0-.656-2.5H12.18c.174.782.282 1.623.312 2.5zM11.27 2.461c.247.464.462.98.64 1.539h1.835a7 7 0 0 0-3.072-2.472c.218.284.418.598.597.933M10.855 4a8 8 0 0 0-.468-1.068C9.835 1.897 9.17 1.282 8.5 1.077V4z",
-                                viewbox: "0 0 16 16",
-                                size: "16",
-                            },
-                            {
-                                label: "Table",
-                                content: table,
-                                icon: "M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2zm15 2h-4v3h4zm0 4h-4v3h4zm0 4h-4v3h3a1 1 0 0 0 1-1zm-5 3v-3H6v3zm-5 0v-3H1v2a1 1 0 0 0 1 1zm-4-4h4V8H1zm0-4h4V4H1zm5-3v3h4V4zm4 4H6v3h4z",
-                                viewbox: "0 0 16 16",
-                                size: "16",
-                            },
-                        ]}
-                    ></Tabs>
-                ) : (
-                    <div className="flex flex-1 min-w-0 h-full">
-                        <div className="flex-[0_0_57%] min-w-0">{map}</div>
-                        <div className="flex-[0_0_43%] min-w-0">{table}</div>
-                    </div>
+            <div className="flex flex-col flex-1 min-h-0">
+                <div className="flex relative flex-1 min-h-0">
+                    <LeftColumn toggled_ui={toggled_ui} />
+                    {is_md_device ? (
+                        <Tabs
+                            local_storage_name="mobile_tab"
+                            tabs={[
+                                {
+                                    label: "Map",
+                                    content: map,
+                                    icon: "M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m7.5-6.923c-.67.204-1.335.82-1.887 1.855A8 8 0 0 0 5.145 4H7.5zM4.09 4a9.3 9.3 0 0 1 .64-1.539 7 7 0 0 1 .597-.933A7.03 7.03 0 0 0 2.255 4zm-.582 3.5c.03-.877.138-1.718.312-2.5H1.674a7 7 0 0 0-.656 2.5zM4.847 5a12.5 12.5 0 0 0-.338 2.5H7.5V5zM8.5 5v2.5h2.99a12.5 12.5 0 0 0-.337-2.5zM4.51 8.5a12.5 12.5 0 0 0 .337 2.5H7.5V8.5zm3.99 0V11h2.653c.187-.765.306-1.608.338-2.5zM5.145 12q.208.58.468 1.068c.552 1.035 1.218 1.65 1.887 1.855V12zm.182 2.472a7 7 0 0 1-.597-.933A9.3 9.3 0 0 1 4.09 12H2.255a7 7 0 0 0 3.072 2.472M3.82 11a13.7 13.7 0 0 1-.312-2.5h-2.49c.062.89.291 1.733.656 2.5zm6.853 3.472A7 7 0 0 0 13.745 12H11.91a9.3 9.3 0 0 1-.64 1.539 7 7 0 0 1-.597.933M8.5 12v2.923c.67-.204 1.335-.82 1.887-1.855q.26-.487.468-1.068zm3.68-1h2.146c.365-.767.594-1.61.656-2.5h-2.49a13.7 13.7 0 0 1-.312 2.5m2.802-3.5a7 7 0 0 0-.656-2.5H12.18c.174.782.282 1.623.312 2.5zM11.27 2.461c.247.464.462.98.64 1.539h1.835a7 7 0 0 0-3.072-2.472c.218.284.418.598.597.933M10.855 4a8 8 0 0 0-.468-1.068C9.835 1.897 9.17 1.282 8.5 1.077V4z",
+                                    viewbox: "0 0 16 16",
+                                    size: "16",
+                                },
+                                {
+                                    label: "Table",
+                                    content: table,
+                                    icon: "M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2zm15 2h-4v3h4zm0 4h-4v3h4zm0 4h-4v3h3a1 1 0 0 0 1-1zm-5 3v-3H6v3zm-5 0v-3H1v2a1 1 0 0 0 1 1zm-4-4h4V8H1zm0-4h4V4H1zm5-3v3h4V4zm4 4H6v3h4z",
+                                    viewbox: "0 0 16 16",
+                                    size: "16",
+                                },
+                            ]}
+                        ></Tabs>
+                    ) : (
+                        <div className="flex flex-1 min-w-0 h-full">
+                            <div className="flex-[0_0_57%] min-w-0">{map}</div>
+                            <div className="flex-[0_0_43%] min-w-0">{table}</div>
+                        </div>
+                    )}
+                    <SidePanel
+                        toggled_ui={toggled_ui}
+                        set_cat_to_spot={set_cat_to_spot}
+                        active_view={active_view}
+                        set_active_view={set_active_view}
+                    />
+                </div>
+                {is_history_mode && (
+                    <HistoryBar
+                        start={history_start}
+                        end={history_end}
+                        set_start={set_history_start}
+                        set_end={set_history_end}
+                        window_size_ms={window_size_ms}
+                        set_window_size_ms={set_window_size_ms}
+                    />
                 )}
-                <SidePanel
-                    toggled_ui={toggled_ui}
-                    set_cat_to_spot={set_cat_to_spot}
-                    active_view={active_view}
-                    set_active_view={set_active_view}
-                />
             </div>
         </div>
+    );
+}
+
+function MainContainer() {
+    const [history_start, set_history_start] = useState(null);
+    const [history_end, set_history_end] = useState(null);
+    const [window_size_ms, set_window_size_ms] = useState(15 * 60_000);
+
+    return (
+        <SpotDataProvider
+            startTime={history_start}
+            endTime={history_end}
+            window_size_ms={window_size_ms}
+        >
+            <MainContent
+                history_start={history_start}
+                history_end={history_end}
+                set_history_start={set_history_start}
+                set_history_end={set_history_end}
+                window_size_ms={window_size_ms}
+                set_window_size_ms={set_window_size_ms}
+            />
+        </SpotDataProvider>
     );
 }
 

--- a/ui/src/components/MapControls.jsx
+++ b/ui/src/components/MapControls.jsx
@@ -29,6 +29,8 @@ function MapControls({
     is_map_fullscreen,
     toggle_map_fullscreen,
     is_mobile,
+    is_history_mode,
+    toggle_history,
 }) {
     const { colors } = useColors();
     const { propagation } = useRestData();
@@ -304,6 +306,29 @@ function MapControls({
                     )}
                     <button
                         type="button"
+                        onClick={toggle_history}
+                        className="flex h-10 w-10 items-center justify-center rounded-lg"
+                        style={{
+                            ...control_button_style,
+                            ...(is_history_mode
+                                ? { color: colors.buttons.active ?? "#3b82f6" }
+                                : {}),
+                        }}
+                        aria-label={is_history_mode ? "Exit history mode" : "Enter history mode"}
+                        title={is_history_mode ? "Exit history mode" : "Enter history mode"}
+                    >
+                        <svg
+                            height="24"
+                            width="24"
+                            viewBox="0 0 512 512"
+                            fill="currentColor"
+                            aria-hidden="true"
+                        >
+                            <path d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200zm61.8-104.4l-84.9-61.7c-3.1-2.3-4.9-5.9-4.9-9.7V116c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v141.7l66.8 48.6c5.4 3.9 6.5 11.4 2.6 16.8L334.6 349c-3.9 5.3-11.4 6.5-16.8 2.6z" />
+                        </svg>
+                    </button>
+                    <button
+                        type="button"
                         onClick={toggle_controls_panel}
                         className="flex h-10 w-10 items-center justify-center rounded-lg"
                         style={control_button_style}
@@ -502,7 +527,7 @@ function MapControls({
             </div>
             {propagation && settings.propagation_displayed && (
                 <div
-                    className="fixed md:absolute bottom-0 md:bottom-2 right-0 right-2 z-40 flex justify-end md:justify-center gap-2"
+                    className="fixed md:absolute bottom-0 md:bottom-2 right-2 z-40 flex justify-end md:justify-center gap-2"
                     style={{ backgroundColor: colors.theme.background }}
                 >
                     <PropagationBar

--- a/ui/src/components/TopBar.jsx
+++ b/ui/src/components/TopBar.jsx
@@ -2,7 +2,7 @@ import SubmitSpot from "@/components/SubmitSpot.jsx";
 import Clock from "@/components/Clock.jsx";
 import NetworkState from "@/components/NetworkState.jsx";
 import Spinner from "@/components/ui/Spinner.jsx";
-import Settings from "@/components/settings/Settings.jsx";
+import { Settings } from "@/components/settings/Settings.jsx";
 import ColorPicker from "@/components/ui/ColorPicker.jsx";
 import Select from "@/components/ui/Select.jsx";
 import Button from "@/components/ui/Button.jsx";

--- a/ui/src/components/history/HistoryBar.jsx
+++ b/ui/src/components/history/HistoryBar.jsx
@@ -3,6 +3,7 @@ import { useColors } from "@/hooks/useColors";
 import Select from "@/components/ui/Select.jsx";
 import Button from "@/components/ui/Button.jsx";
 import HistoryBarSettings from "@/components/history/HistoryBarSettings.jsx";
+import { useLocalStorage } from "@uidotdev/usehooks";
 
 const PRESETS = [
     { label: "8h", hours: 8 },
@@ -33,19 +34,15 @@ function tick_interval_hours(range_hours) {
     return 12;
 }
 
-function to_datetime_local(date) {
-    const pad = n => String(n).padStart(2, "0");
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-}
-
 function HistoryBar({ start, end, set_start, set_end, window_size_ms, set_window_size_ms }) {
     const { colors } = useColors();
 
-    const [display_hours, set_display_hours] = useState(24);
+    const [display_hours, set_display_hours] = useLocalStorage("history-display-hours", 24);
     const [is_playing, set_is_playing] = useState(false);
-    const [time_between_shifts, set_time_between_shifts] = useState(3);
-    const [editing_start, set_editing_start] = useState(false);
-    const [start_input, set_start_input] = useState("");
+    const [time_between_shifts, set_time_between_shifts] = useLocalStorage(
+        "history-time-between-shifts",
+        3,
+    );
 
     const bar_ref = useRef(null);
     const drag_ref = useRef(null);
@@ -224,23 +221,6 @@ function HistoryBar({ start, end, set_start, set_end, window_size_ms, set_window
             window.removeEventListener("mouseup", on_mouse_up);
         };
     }, [bar_start_ms, display_ms, bar_end_ms, set_start, set_end, set_window_size_ms]);
-
-    // --- Jump to time ---
-    function open_start_editor() {
-        set_start_input(to_datetime_local(start));
-        set_is_playing(false);
-        set_editing_start(true);
-    }
-
-    function apply_start() {
-        const new_start = new Date(start_input);
-        if (!isNaN(new_start.getTime())) {
-            const new_end = new Date(new_start.getTime() + window_ms);
-            set_start(new_start);
-            set_end(new_end);
-        }
-        set_editing_start(false);
-    }
 
     const btn_style = {
         background: colors.theme.background,

--- a/ui/src/components/history/HistoryBar.jsx
+++ b/ui/src/components/history/HistoryBar.jsx
@@ -1,0 +1,398 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useColors } from "@/hooks/useColors";
+import Select from "@/components/ui/Select.jsx";
+import Button from "@/components/ui/Button.jsx";
+import HistoryBarSettings from "@/components/history/HistoryBarSettings.jsx";
+
+const PRESETS = [
+    { label: "8h", hours: 8 },
+    { label: "12h", hours: 12 },
+    { label: "24h", hours: 24 },
+    { label: "48h", hours: 48 },
+    { label: "72h", hours: 72 },
+];
+
+const MIN_WINDOW_MS = 15 * 60_000; // m * ms/m = ms
+const MAX_WINDOW_MS = 8 * 60 * 60_000; // H * m/H * ms/m = ms
+
+function fmt_utc_hhmm(date) {
+    const h = String(date.getUTCHours()).padStart(2, "0");
+    const m = String(date.getUTCMinutes()).padStart(2, "0");
+    return `${h}:${m}`;
+}
+
+function fmt_utc_date(date) {
+    return date.toUTCString().slice(5, 11);
+}
+
+function tick_interval_hours(range_hours) {
+    if (range_hours <= 8) return 1;
+    if (range_hours <= 12) return 2;
+    if (range_hours <= 24) return 4;
+    if (range_hours <= 48) return 8;
+    return 12;
+}
+
+function to_datetime_local(date) {
+    const pad = n => String(n).padStart(2, "0");
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function HistoryBar({ start, end, set_start, set_end, window_size_ms, set_window_size_ms }) {
+    const { colors } = useColors();
+
+    const [display_hours, set_display_hours] = useState(24);
+    const [is_playing, set_is_playing] = useState(false);
+    const [time_between_shifts, set_time_between_shifts] = useState(3);
+    const [editing_start, set_editing_start] = useState(false);
+    const [start_input, set_start_input] = useState("");
+
+    const bar_ref = useRef(null);
+    const drag_ref = useRef(null);
+    const interval_ref = useRef(null);
+
+    // Bar always ends at now on the right
+    const now_ms = Date.now();
+    const display_ms = display_hours * 3_600_000;
+    const bar_start_ms = now_ms - display_ms;
+    const bar_end_ms = now_ms;
+
+    const window_ms = window_size_ms || end.getTime() - start.getTime();
+
+    // Position of the window within the bar (0–1)
+    const win_left = Math.max(0, Math.min(1, (start.getTime() - bar_start_ms) / display_ms));
+    const win_width = Math.max(0, Math.min(1 - win_left, window_ms / display_ms));
+
+    // Tick marks
+    const interval_ms = tick_interval_hours(display_hours) * 3_600_000;
+    const first_tick = Math.ceil(bar_start_ms / interval_ms) * interval_ms;
+    const multi_day = display_hours > 24;
+    const ticks = [];
+    for (let t = first_tick; t < bar_end_ms; t += interval_ms) {
+        const frac = (t - bar_start_ms) / display_ms;
+        const date = new Date(t);
+        const is_midnight = date.getUTCHours() === 0;
+        ticks.push({ ms: t, frac, date, is_midnight });
+    }
+
+    // --- Preset: change display range, clamp window to new bar ---
+    function apply_preset(hours) {
+        const new_now = Date.now();
+        const new_bar_start = new_now - hours * 3_600_000;
+        let s = start.getTime();
+        let e = end.getTime();
+        const win = e - s;
+        if (s < new_bar_start) {
+            s = new_bar_start;
+            e = s + win;
+        }
+        if (e > new_now) {
+            e = new_now;
+            s = Math.max(new_bar_start, e - win);
+        }
+        set_display_hours(hours);
+        set_start(new Date(s));
+        set_end(new Date(e));
+    }
+
+    // --- Step / play ---
+    function shift(direction) {
+        const delta_ms = window_ms * direction;
+        let new_start = start.getTime() + delta_ms;
+        let new_end = end.getTime() + delta_ms;
+        if (new_start < bar_start_ms) {
+            new_start = bar_start_ms;
+            new_end = new_start + window_ms;
+        }
+        if (new_end > bar_end_ms) {
+            new_end = bar_end_ms;
+            new_start = new_end - window_ms;
+        }
+        set_start(new Date(new_start));
+        set_end(new Date(new_end));
+    }
+
+    function step_forward() {
+        shift(1);
+    }
+    function step_back() {
+        shift(-1);
+    }
+
+    useEffect(() => {
+        if (is_playing) {
+            interval_ref.current = setInterval(step_forward, time_between_shifts * 1000);
+        } else {
+            clearInterval(interval_ref.current);
+        }
+        return () => clearInterval(interval_ref.current);
+    }, [is_playing, window_ms, time_between_shifts, start, end]);
+
+    // --- Drag ---
+    const on_bar_mouse_down = useCallback(
+        e => {
+            if (!bar_ref.current) return;
+            e.preventDefault();
+            const rect = bar_ref.current.getBoundingClientRect();
+            const frac = (e.clientX - rect.left) / rect.width;
+            const clicked_ms = bar_start_ms + frac * display_ms;
+            const raw_start = clicked_ms - window_ms / 2;
+            const new_start = Math.max(bar_start_ms, Math.min(bar_end_ms - window_ms, raw_start));
+            const new_end = new_start + window_ms;
+            set_start(new Date(new_start));
+            set_end(new Date(new_end));
+            set_is_playing(false);
+            drag_ref.current = {
+                type: "move",
+                start_x: e.clientX,
+                orig_start_ms: new_start,
+                orig_end_ms: new_end,
+            };
+        },
+        [bar_start_ms, display_ms, window_ms, bar_end_ms],
+    );
+
+    const on_window_mouse_down = useCallback(
+        e => {
+            e.stopPropagation();
+            e.preventDefault();
+            set_is_playing(false);
+            drag_ref.current = {
+                type: "move",
+                start_x: e.clientX,
+                orig_start_ms: start.getTime(),
+                orig_end_ms: end.getTime(),
+            };
+        },
+        [start, end],
+    );
+
+    const on_resize_mouse_down = useCallback(
+        e => {
+            e.stopPropagation();
+            e.preventDefault();
+            set_is_playing(false);
+            drag_ref.current = {
+                type: "resize",
+                start_x: e.clientX,
+                orig_start_ms: start.getTime(),
+                orig_end_ms: end.getTime(),
+            };
+        },
+        [start, end],
+    );
+
+    useEffect(() => {
+        function on_mouse_move(e) {
+            if (!drag_ref.current || !bar_ref.current) return;
+            const rect = bar_ref.current.getBoundingClientRect();
+            const dx_ms = ((e.clientX - drag_ref.current.start_x) / rect.width) * display_ms;
+
+            if (drag_ref.current.type === "move") {
+                let s = drag_ref.current.orig_start_ms + dx_ms;
+                let en = drag_ref.current.orig_end_ms + dx_ms;
+                if (s < bar_start_ms) {
+                    en += bar_start_ms - s;
+                    s = bar_start_ms;
+                }
+                if (en > bar_end_ms) {
+                    s -= en - bar_end_ms;
+                    en = bar_end_ms;
+                }
+                set_start(new Date(s));
+                set_end(new Date(en));
+            } else {
+                let new_end_ms = drag_ref.current.orig_end_ms + dx_ms;
+                const new_win = Math.max(
+                    MIN_WINDOW_MS,
+                    Math.min(MAX_WINDOW_MS, new_end_ms - drag_ref.current.orig_start_ms),
+                );
+                new_end_ms = drag_ref.current.orig_start_ms + new_win;
+                set_end(new Date(Math.min(new_end_ms, bar_end_ms)));
+                set_window_size_ms(new_win);
+            }
+        }
+
+        function on_mouse_up() {
+            drag_ref.current = null;
+        }
+
+        window.addEventListener("mousemove", on_mouse_move);
+        window.addEventListener("mouseup", on_mouse_up);
+        return () => {
+            window.removeEventListener("mousemove", on_mouse_move);
+            window.removeEventListener("mouseup", on_mouse_up);
+        };
+    }, [bar_start_ms, display_ms, bar_end_ms, set_start, set_end, set_window_size_ms]);
+
+    // --- Jump to time ---
+    function open_start_editor() {
+        set_start_input(to_datetime_local(start));
+        set_is_playing(false);
+        set_editing_start(true);
+    }
+
+    function apply_start() {
+        const new_start = new Date(start_input);
+        if (!isNaN(new_start.getTime())) {
+            const new_end = new Date(new_start.getTime() + window_ms);
+            set_start(new_start);
+            set_end(new_end);
+        }
+        set_editing_start(false);
+    }
+
+    const btn_style = {
+        background: colors.theme.background,
+        border: `1px solid ${colors.theme.text}55`,
+        color: colors.theme.text,
+    };
+    return (
+        <div
+            className="flex flex-row px-3 py-1 gap-1 select-none"
+            style={{
+                background: colors.theme.background,
+                borderTop: `1px solid ${colors.theme.borders}`,
+                color: colors.theme.text,
+            }}
+        >
+            {/* Controls row */}
+            <div className="flex flex-row items-center gap-2 text-xs">
+                <div
+                    className="w-px self-stretch mx-1"
+                    style={{ background: `${colors.theme.text}30` }}
+                />
+
+                {/* Step / play controls */}
+                <Button
+                    onClick={step_back}
+                    className="h-full aspect-square rounded"
+                    style={btn_style}
+                    title="Step back one window"
+                >
+                    ◀◀
+                </Button>
+                <Button
+                    onClick={() => set_is_playing(p => !p)}
+                    className="h-full aspect-square rounded"
+                    style={btn_style}
+                    title={is_playing ? "Pause" : "Play forward"}
+                >
+                    {is_playing ? "⏸" : "▶"}
+                </Button>
+                <Button
+                    onClick={step_forward}
+                    className="h-full aspect-square rounded"
+                    style={btn_style}
+                    title="Step forward one window"
+                >
+                    ▶▶
+                </Button>
+            </div>
+
+            {/* Timeline bar — right edge = now */}
+            <div className="relative w-full h-full">
+                {/* Track */}
+                <div
+                    ref={bar_ref}
+                    className="absolute inset-0 rounded cursor-crosshair"
+                    style={{ background: colors.theme.columns }}
+                    onMouseDown={on_bar_mouse_down}
+                />
+
+                {/* Selected window */}
+                <div
+                    className="absolute top-0 bottom-0 rounded cursor-grab active:cursor-grabbing"
+                    style={{
+                        left: `${win_left * 100}%`,
+                        width: `${win_width * 100}%`,
+                        background: "#3b82f6",
+                        opacity: 0.65,
+                        minWidth: "4px",
+                    }}
+                    onMouseDown={on_window_mouse_down}
+                >
+                    <div
+                        className="absolute right-0 top-0 bottom-0 w-2 cursor-ew-resize z-20 flex items-center justify-center"
+                        onMouseDown={on_resize_mouse_down}
+                        title="Drag to resize window"
+                    >
+                        <div className="w-0.5 h-3 rounded bg-white opacity-80" />
+                    </div>
+                </div>
+
+                {/* Tick marks */}
+                {ticks.map(tick => {
+                    const is_last = tick.frac > 0.95;
+                    return (
+                        <div
+                            key={tick.ms}
+                            className="absolute top-0 bottom-0 flex flex-col items-center pointer-events-none"
+                            style={{
+                                left: `${tick.frac * 100}%`,
+                                transform: is_last
+                                    ? "translateX(-100%)"
+                                    : tick.frac < 0.05
+                                      ? "none"
+                                      : "translateX(-50%)",
+                            }}
+                        >
+                            <div
+                                className="w-px opacity-75"
+                                style={{
+                                    height: tick.is_midnight && multi_day ? "100%" : "12px",
+                                    background: colors.theme.text,
+                                }}
+                            />
+                            {tick.is_midnight && multi_day ? (
+                                <span
+                                    className="text-[12px] leading-none mt-0.5 whitespace-nowrap font-medium"
+                                    style={{
+                                        color: colors.theme.text,
+                                        opacity: 1,
+                                    }}
+                                >
+                                    {fmt_utc_date(tick.date)}
+                                </span>
+                            ) : (
+                                <span
+                                    className="text-[12px] leading-none mt-0.5 whitespace-nowrap"
+                                    style={{
+                                        color: colors.theme.text,
+                                        opacity: 0.8,
+                                    }}
+                                >
+                                    {fmt_utc_hhmm(tick.date)}
+                                </span>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+            {/* Preset display-range buttons */}
+            <Select
+                className="w-min"
+                value={display_hours}
+                onChange={e => apply_preset(Number(e.target.value))}
+            >
+                {PRESETS.map(p => (
+                    <option key={p.hours} value={p.hours}>
+                        {p.label}
+                    </option>
+                ))}
+            </Select>
+
+            {/* Settings button */}
+            <HistoryBarSettings
+                window_ms={window_ms}
+                set_window_size_ms={set_window_size_ms}
+                start={start}
+                set_end={set_end}
+                time_between_shifts={time_between_shifts}
+                set_time_between_shifts={set_time_between_shifts}
+            />
+        </div>
+    );
+}
+
+export default HistoryBar;

--- a/ui/src/components/history/HistoryBarSettings.jsx
+++ b/ui/src/components/history/HistoryBarSettings.jsx
@@ -1,0 +1,194 @@
+import { useState, useEffect, useRef } from "react";
+import { useColors } from "@/hooks/useColors";
+import Button from "@/components/ui/Button.jsx";
+import Popup from "@/components/ui/Popup.jsx";
+import Input from "@/components/ui/Input";
+import { SettingsIcon } from "@/components/settings/Settings";
+
+const MAX_WINDOW_MS = 8 * 60 * 60_000;
+
+function HistoryBarSettings({
+    window_ms,
+    set_window_size_ms,
+    start,
+    set_end,
+    time_between_shifts,
+    set_time_between_shifts,
+}) {
+    const { colors } = useColors();
+    const [show_settings, set_show_settings] = useState(false);
+    const [window_input, set_window_input] = useState("");
+    const [speed_input, set_speed_input] = useState("");
+
+    const settings_btn_ref = useRef(null);
+    const settings_popup_ref = useRef(null);
+
+    const window_min = Math.round(window_ms / 60_000);
+
+    useEffect(() => {
+        if (show_settings) {
+            set_window_input(String(window_min));
+        }
+    }, [window_ms]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        if (!show_settings) return;
+        set_window_input(String(window_min));
+        set_speed_input(String(time_between_shifts));
+        function handle_click(e) {
+            if (
+                settings_btn_ref.current?.contains(e.target) ||
+                settings_popup_ref.current?.contains(e.target)
+            )
+                return;
+            set_show_settings(false);
+        }
+        document.addEventListener("mousedown", handle_click);
+        return () => document.removeEventListener("mousedown", handle_click);
+    }, [show_settings]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    function apply_window_input() {
+        const v = parseInt(window_input);
+        if (!isNaN(v) && v >= 1) {
+            const new_ms = Math.min(v * 60_000, MAX_WINDOW_MS);
+            set_window_size_ms(new_ms);
+            set_end(new Date(start.getTime() + new_ms));
+            set_window_input(String(Math.round(new_ms / 60_000)));
+        } else {
+            set_window_input(String(window_min));
+        }
+    }
+
+    function apply_speed_input() {
+        const v = parseInt(speed_input);
+        if (!isNaN(v) && v >= 1 && v <= 60) {
+            set_time_between_shifts(v);
+        } else {
+            set_speed_input(String(time_between_shifts));
+        }
+    }
+
+    const btn_style = {
+        background: colors.theme.background,
+        border: `1px solid ${colors.theme.text}55`,
+        color: colors.theme.text,
+    };
+
+    return (
+        <div ref={settings_btn_ref} className="relative flex items-center gap-x-2">
+            <Button
+                onClick={() => set_show_settings(v => !v)}
+                className="h-full aspect-square rounded"
+                style={{
+                    ...btn_style,
+                    background: show_settings ? "#3b82f6" : btn_style.background,
+                    border: show_settings ? "1px solid #3b82f6" : btn_style.border,
+                    color: show_settings ? "white" : btn_style.color,
+                }}
+                title="Playback settings"
+            >
+                <SettingsIcon />
+            </Button>
+
+            {show_settings && (
+                <Popup anchor_ref={settings_btn_ref} vertical_offset={-4} keep_in_view={true}>
+                    <div
+                        ref={settings_popup_ref}
+                        className="pointer-events-auto rounded-lg shadow-xl px-4 py-3 flex flex-col gap-3 text-sm"
+                        style={{
+                            background: colors.theme.background,
+                            border: `1px solid ${colors.theme.borders}`,
+                            color: colors.theme.text,
+                            minWidth: "210px",
+                        }}
+                    >
+                        <label className="flex items-center justify-between gap-3">
+                            <span>Window size (min)</span>
+                            <Input
+                                type="text"
+                                value={window_input}
+                                onChange={e => set_window_input(e.target.value)}
+                                onBlur={apply_window_input}
+                                onKeyDown={e => {
+                                    if (e.key === "Enter") {
+                                        apply_window_input();
+                                        e.target.blur();
+                                    }
+                                    if (e.key === "Escape") {
+                                        set_window_input(String(window_min));
+                                        e.target.blur();
+                                    }
+                                }}
+                                className="w-16 text-right"
+                            />
+                        </label>
+                        <div className="flex items-center justify-between gap-3">
+                            <span>Playback speed (s)</span>
+                            <div className="flex items-center gap-1">
+                                <div
+                                    className="flex items-stretch rounded-lg overflow-hidden"
+                                    style={{ backgroundColor: colors.theme.input_background }}
+                                >
+                                    <Input
+                                        type="text"
+                                        value={speed_input}
+                                        onChange={e => set_speed_input(e.target.value)}
+                                        onBlur={apply_speed_input}
+                                        onKeyDown={e => {
+                                            if (e.key === "Enter") {
+                                                apply_speed_input();
+                                                e.target.blur();
+                                            }
+                                            if (e.key === "Escape") {
+                                                set_speed_input(String(time_between_shifts));
+                                                e.target.blur();
+                                            }
+                                        }}
+                                        className="w-10 py-2 pl-3 pr-1 leading-tight text-center outline-none"
+                                        style={{
+                                            backgroundColor: "transparent",
+                                            color: colors.theme.text,
+                                        }}
+                                    />
+                                    <div
+                                        className="flex flex-col"
+                                        style={{ borderLeft: `1px solid ${colors.theme.text}33` }}
+                                    >
+                                        <button
+                                            className="flex-1 flex items-center justify-center px-1.5 hover:bg-white/10 active:bg-white/20"
+                                            style={{
+                                                color: colors.theme.text,
+                                                fontSize: "9px",
+                                                borderBottom: `1px solid ${colors.theme.text}33`,
+                                            }}
+                                            onClick={() => {
+                                                const next = Math.min(60, time_between_shifts + 1);
+                                                set_time_between_shifts(next);
+                                                set_speed_input(String(next));
+                                            }}
+                                        >
+                                            ▲
+                                        </button>
+                                        <button
+                                            className="flex-1 flex items-center justify-center px-1.5 hover:bg-white/10 active:bg-white/20"
+                                            style={{ color: colors.theme.text, fontSize: "9px" }}
+                                            onClick={() => {
+                                                const next = Math.max(1, time_between_shifts - 1);
+                                                set_time_between_shifts(next);
+                                                set_speed_input(String(next));
+                                            }}
+                                        >
+                                            ▼
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </Popup>
+            )}
+        </div>
+    );
+}
+
+export default HistoryBarSettings;

--- a/ui/src/components/settings/Settings.jsx
+++ b/ui/src/components/settings/Settings.jsx
@@ -209,4 +209,4 @@ function Settings({ set_map_controls, set_radius_in_km }) {
     );
 }
 
-export default Settings;
+export { Settings, SettingsIcon };

--- a/ui/src/hooks/useHistorySpots.js
+++ b/ui/src/hooks/useHistorySpots.js
@@ -1,0 +1,124 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { modes, continents } from "@/data/filters_data.js";
+import { shorten_dxcc } from "@/data/flags.js";
+
+function normalize_band(band) {
+    if (band == 2) return "VHF";
+    if (band == 0.7) return "UHF";
+    if (band < 1) return "SHF";
+    return band;
+}
+
+function normalize_spots(spots, id_ref) {
+    return spots
+        .map(spot => {
+            spot.id = id_ref.current++;
+            if (spot.mode === "DIGITAL") spot.mode = "DIGI";
+            spot.band = normalize_band(spot.band);
+            spot.dx_country = shorten_dxcc(spot.dx_country);
+            spot.spotter_country = shorten_dxcc(spot.spotter_country);
+            return spot;
+        })
+        .filter(spot => {
+            if (!modes.includes(spot.mode)) return false;
+            if (!continents.includes(spot.dx_continent)) return false;
+            if (!continents.includes(spot.spotter_continent)) return false;
+            return true;
+        });
+}
+
+async function fetch_window(start_unix, end_unix, signal) {
+    const res = await fetch(`/history?start_time=${start_unix}&end_time=${end_unix}`, { signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    return data.spots;
+}
+
+// In-memory cache: key = "start_unix:end_unix" → normalized spots array
+const spot_cache = new Map();
+
+export default function useHistorySpots(startTime, endTime, window_size_ms) {
+    const [raw_spots, set_raw_spots] = useState([]);
+    const [fetch_state, set_fetch_state] = useState("idle");
+    const next_id_ref = useRef(1_000_000);
+    const prefetch_controllers = useRef(new Map());
+
+    const get_or_fetch = useCallback(async (start_ms, end_ms, signal) => {
+        const key = `${Math.floor(start_ms / 1000)}:${Math.floor(end_ms / 1000)}`;
+        if (spot_cache.has(key)) return spot_cache.get(key);
+
+        const raw = await fetch_window(
+            Math.floor(start_ms / 1000),
+            Math.floor(end_ms / 1000),
+            signal,
+        );
+        const normalized = normalize_spots(raw, next_id_ref);
+        spot_cache.set(key, normalized);
+        return normalized;
+    }, []);
+
+    // Prefetch a window silently; abort any previous prefetch for same key
+    const prefetch = useCallback(
+        (start_ms, end_ms) => {
+            const key = `${Math.floor(start_ms / 1000)}:${Math.floor(end_ms / 1000)}`;
+            if (spot_cache.has(key)) return;
+            if (prefetch_controllers.current.has(key)) return;
+
+            const controller = new AbortController();
+            prefetch_controllers.current.set(key, controller);
+
+            get_or_fetch(start_ms, end_ms, controller.signal)
+                .catch(() => {
+                    // Silence prefetch errors (abort, network, etc.)
+                })
+                .finally(() => {
+                    prefetch_controllers.current.delete(key);
+                });
+        },
+        [get_or_fetch],
+    );
+
+    useEffect(() => {
+        if (!startTime || !endTime) {
+            set_raw_spots([]);
+            set_fetch_state("idle");
+            return;
+        }
+
+        const start_ms = startTime.getTime();
+        const end_ms = endTime.getTime();
+        const win = window_size_ms || end_ms - start_ms;
+
+        const controller = new AbortController();
+        set_fetch_state("loading");
+
+        get_or_fetch(start_ms, end_ms, controller.signal)
+            .then(spots => {
+                set_raw_spots(spots);
+                set_fetch_state("done");
+
+                // Prefetch next and previous windows
+                const now_ms = Date.now();
+                const next_start = end_ms;
+                const next_end = end_ms + win;
+                const prev_start = start_ms - win;
+                const prev_end = start_ms;
+
+                if (next_end <= now_ms + 60_000) {
+                    prefetch(next_start, next_end);
+                }
+                if (prev_start >= 0) {
+                    prefetch(prev_start, prev_end);
+                }
+            })
+            .catch(err => {
+                if (err.name === "AbortError") return;
+                console.error("Failed to fetch history spots:", err);
+                set_fetch_state("error");
+            });
+
+        return () => controller.abort();
+    }, [startTime, endTime]);
+
+    return { raw_spots, fetch_state };
+}

--- a/ui/src/hooks/useSpotData.jsx
+++ b/ui/src/hooks/useSpotData.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect } from "react";
 import useSpotWebSocket from "./useSpotWebSocket";
+import useHistorySpots from "./useHistorySpots";
 import useSpotFiltering from "./useSpotFiltering";
 import { useSpotInteraction } from "./useSpotInteraction";
 import { useFilters } from "./useFilters";
@@ -13,8 +14,21 @@ export function useSpotData() {
     return useContext(SpotDataContext);
 }
 
-export const SpotDataProvider = ({ children }) => {
-    const { raw_spots, new_spot_ids, network_state } = useSpotWebSocket();
+export const SpotDataProvider = ({ children, startTime, endTime, window_size_ms }) => {
+    const {
+        raw_spots: ws_raw_spots,
+        new_spot_ids: ws_new_spot_ids,
+        network_state,
+    } = useSpotWebSocket();
+    const { raw_spots: history_raw_spots, fetch_state } = useHistorySpots(
+        startTime,
+        endTime,
+        window_size_ms,
+    );
+
+    const is_history_mode = !!(startTime && endTime);
+    const raw_spots = is_history_mode ? history_raw_spots : ws_raw_spots;
+    const new_spot_ids = is_history_mode ? new Set() : ws_new_spot_ids;
     const {
         spots,
         spots_with_alerts,
@@ -23,7 +37,7 @@ export const SpotDataProvider = ({ children }) => {
         spots_per_band_count,
         spots_per_mode_count,
         current_freq_spots,
-    } = useSpotFiltering(raw_spots);
+    } = useSpotFiltering(raw_spots, is_history_mode);
 
     const { pinned_spot } = useSpotInteraction();
     const { settings } = useSettings();
@@ -33,6 +47,7 @@ export const SpotDataProvider = ({ children }) => {
     // Play alert sound when new alerted spots arrive
     useEffect(() => {
         if (
+            !is_history_mode &&
             new_spot_ids.size > 0 &&
             settings.alert_sound_enabled &&
             callsign_filters.is_alert_filters_active
@@ -74,6 +89,8 @@ export const SpotDataProvider = ({ children }) => {
                 spots_per_mode_count,
                 network_state,
                 current_freq_spots,
+                is_history_mode,
+                fetch_state,
             }}
         >
             {children}

--- a/ui/src/hooks/useSpotFiltering.js
+++ b/ui/src/hooks/useSpotFiltering.js
@@ -18,7 +18,7 @@ function limit_count(count) {
     return Math.min(count, 99);
 }
 
-export default function useSpotFiltering(raw_spots) {
+export default function useSpotFiltering(raw_spots, is_history_mode = false) {
     const { filters, callsign_filters } = useFilters();
     const { radio_band, radio_freq, radio_status } = use_radio();
     const { search_query } = useSpotInteraction();
@@ -66,7 +66,8 @@ export default function useSpotFiltering(raw_spots) {
                     }
                 }
 
-                const is_in_time_limit = current_time - spot.time < filters.time_limit;
+                const is_in_time_limit =
+                    is_history_mode || current_time - spot.time < filters.time_limit;
 
                 const is_matching_search = spot.dx_callsign
                     .toLowerCase()
@@ -139,6 +140,7 @@ export default function useSpotFiltering(raw_spots) {
         table_sort,
         filters.show_only_latest_spot,
         search_query,
+        is_history_mode,
     ]);
 
     const spots_per_band_count = useMemo(() => {

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -5,7 +5,6 @@ import { BrowserRouter, Routes, Route } from "react-router";
 import MainContainer from "@/components/MainContainer.jsx";
 import Addons from "@/components/addons/Addons";
 import OmniRigError from "@/components/OmniRigError.jsx";
-import { SpotDataProvider } from "@/hooks/useSpotData";
 import { SpotInteractionProvider } from "@/hooks/useSpotInteraction";
 import { RestDataProvider } from "@/hooks/useRestData";
 import { FiltersProvider } from "@/hooks/useFilters";
@@ -27,9 +26,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
                                     <RadioProvider>
                                         <RestDataProvider>
                                             <SpotInteractionProvider>
-                                                <SpotDataProvider>
-                                                    <MainContainer />
-                                                </SpotDataProvider>
+                                                <MainContainer />
                                             </SpotInteractionProvider>
                                         </RestDataProvider>
                                     </RadioProvider>

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
             "/catserver": "https://holycluster-dev.iarc.org",
             "/dxpeditions": "https://holycluster-dev.iarc.org",
             "/cluster_stats": "https://holycluster-dev.iarc.org",
+            "/history": "https://holycluster-dev.iarc.org",
             "/spots_ws": {
                 target: "wss://holycluster-dev.iarc.org",
                 ws: true,


### PR DESCRIPTION
Adds a history mode that lets users browse past spots across a selectable time window, rather than only viewing the live feed.

## Backend

New GET /history?start_time=&end_time= endpoint that queries the database for spots in a given Unix timestamp range (capped at 24 hours)

## Frontend

New useHistorySpots hook that fetches from /history, normalizes spots to match the live format, caches results in memory, and prefetches the next/previous windows in the background
SpotDataProvider now accepts startTime/endTime props and switches between live WebSocket data and historical data accordingly; alert sounds and time-limit filtering are bypassed in history mode
SpotDataProvider moved from main.jsx into MainContainer so history state can flow down to it
Clock icon button added to MapControls to toggle history mode on/off
New HistoryBar component rendered at the bottom of the UI in history mode — an interactive timeline with a draggable/resizable window, step back/forward buttons, play/pause playback, preset display ranges (8h–72h), and a settings popup for window size and playback speed