### PR TITLE
Reload nginx on cert renewal so renewed certs are served

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -128,6 +128,26 @@ services:
     build:
       context: infra/nginx
       dockerfile: Dockerfile.nginx
+    # Mirrors the CMD in Dockerfile.nginx (envsubst + nginx), but adds a
+    # background loop that reloads nginx only when the cert on disk changes.
+    # certbot renews the cert in a separate container and can't reload this
+    # one; checking the fullchain mtime every 6h means we reload on renewal
+    # (~monthly) instead of unconditionally, which avoids leaving lingering
+    # "shutting down" workers holding open websocket connections.
+    # Keep the envsubst/nginx parts in sync with Dockerfile.nginx CMD.
+    command:
+      - /bin/sh
+      - -c
+      - |
+        (
+          last=$$(stat -c %Y /etc/letsencrypt/live/$${DOMAIN}/fullchain.pem 2>/dev/null)
+          while :; do
+            sleep 6h & wait $${!}
+            cur=$$(stat -c %Y /etc/letsencrypt/live/$${DOMAIN}/fullchain.pem 2>/dev/null)
+            [ "$$cur" != "$$last" ] && { nginx -s reload; last=$$cur; }
+          done
+        ) &
+        envsubst '$${DOMAIN}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'
     restart: unless-stopped
     ulimits:
       nofile:


### PR DESCRIPTION
## Problem

The `certbot` container renews certs on disk but **cannot reload the separate `nginx` container**, so a renewed cert would never be served until someone manually ran `nginx -s reload`. Combined with renewal having been broken, the live cert silently approached expiry.

(The immediate outage was a separate, already-resolved issue: the long-running certbot container held a **stale bind mount** to the webroot and couldn't write ACME challenges. Fixed operationally by `docker compose up -d --force-recreate certbot`.)

## Change

Add a background loop to the `nginx` service `command` that watches `fullchain.pem`'s mtime every 6h and runs `nginx -s reload` **only when it changes** (i.e. on renewal, ~monthly).

- Graceful reload, no container restart, no downtime.
- Conditional on mtime so we don't reload 4×/day — that would leave lingering "shutting down" workers holding open websocket connections (HolyCluster proxies websockets).
- `command` mirrors `Dockerfile.nginx`'s `envsubst` + `nginx -g 'daemon off;'` startup (noted in a comment to flag drift).

## Why not a certbot `--deploy-hook`?

A deploy-hook runs inside the certbot container, which can't reach the nginx container without mounting the Docker socket and adding the docker CLI. Reloading from the nginx side keeps both containers minimal.

## Deploy note

The `command` override only takes effect on recreate:

```bash
docker compose up -d --force-recreate nginx
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)