### PR TITLE
Add architecture guide and prioritized improvement backlog

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,762 @@
+# HolyCluster — Architecture Guide
+
+> A maintainer-oriented explanation of how HolyCluster works, end to end.
+> Companion file: [`architecture.html`](architecture.html) (same content, rendered diagrams).
+> See also: [`IMPROVEMENTS.md`](IMPROVEMENTS.md) for the prioritized improvement backlog.
+
+**Audience:** an engineer who has just inherited this project and needs to maintain it.
+
+---
+
+## Table of Contents
+
+1. [What HolyCluster Is](#1-what-holycluster-is)
+2. [System Context — the 10,000 ft View](#2-system-context--the-10000-ft-view)
+3. [Repository Layout](#3-repository-layout)
+4. [The Backend (`backend/`)](#4-the-backend-backend)
+   - [Workspace packages](#41-workspace-packages)
+   - [The spot collection pipeline](#42-the-spot-collection-pipeline)
+   - [Spot enrichment](#43-spot-enrichment)
+   - [Database schema](#44-database-schema)
+   - [The API service](#45-the-api-service)
+   - [WebSocket protocol](#46-websocket-protocol)
+   - [Background jobs](#47-background-jobs)
+   - [Configuration](#48-configuration)
+5. [The Frontend (`ui/`)](#5-the-frontend-ui)
+   - [Tech stack and entry flow](#51-tech-stack-and-entry-flow)
+   - [State management — the provider tree](#52-state-management--the-provider-tree)
+   - [Data flow into the UI](#53-data-flow-into-the-ui)
+   - [The canvas map engine](#54-the-canvas-map-engine)
+   - [Persistence — profiles in localStorage](#55-persistence--profiles-in-localstorage)
+   - [Major features map](#56-major-features-map)
+6. [The CAT Server (`catserver/`)](#6-the-cat-server-catserver)
+   - [The reverse-proxy trick](#61-the-reverse-proxy-trick)
+   - [Modules and rig backends](#62-modules-and-rig-backends)
+   - [Radio control message flow](#63-radio-control-message-flow)
+   - [Packaging and distribution](#64-packaging-and-distribution)
+7. [Infrastructure & Deployment](#7-infrastructure--deployment)
+   - [Docker Compose stack](#71-docker-compose-stack)
+   - [Nginx routing and TLS](#72-nginx-routing-and-tls)
+   - [CI/CD pipelines](#73-cicd-pipelines)
+   - [Production topology](#74-production-topology)
+8. [Development Workflow](#8-development-workflow)
+9. [Maintainer Gotchas](#9-maintainer-gotchas)
+
+---
+
+## 1. What HolyCluster Is
+
+HolyCluster (<https://holycluster.iarc.org>) is a **real-time visualization of the amateur-radio DX cluster network**. Ham radio operators around the world report stations they hear ("spots": *who* heard *whom*, on *what frequency*, in *what mode*, *when*). HolyCluster aggregates those spots from many sources, enriches them with geographic data, and draws them live on an interactive world map so operators can see band activity at a glance and — with the optional desktop **CAT server** — click a spot to instantly tune their physical radio to it.
+
+The product consists of three deliverables built from one monorepo:
+
+| Deliverable | Source | What it is |
+|---|---|---|
+| **Web application** | `ui/` + `backend/` | React SPA served by a FastAPI backend; live spots over WebSocket |
+| **Data platform** | `backend/` | Collectors ingesting telnet DX clusters + POTA/SOTA/WWFF APIs into PostgreSQL/Valkey |
+| **Holy Cluster desktop app** | `catserver/` | Rust Windows app (MSI) bridging the web UI to the operator's radio via OmniRig |
+
+It is developed by Israeli ham operators with support from the IARC (Israel Amateur Radio Club).
+
+---
+
+## 2. System Context — the 10,000 ft View
+
+```mermaid
+flowchart TB
+    subgraph EXT["External data sources"]
+        TELNET["Telnet DX clusters<br/>(DXUSA, VE7CC, K7AR, AI9T, NC7J, WA9PIE-2)"]
+        POTA["POTA API<br/>api.pota.app"]
+        SOTA["SOTA API<br/>api-db2.sota.org.uk"]
+        WWFF["WWFF spots<br/>spots.wwff.co"]
+        QRZ["QRZ.com XML API<br/>(callsign → locator)"]
+        CTY["country-files.com CTY<br/>(prefix → DXCC)"]
+        NOAA["NOAA SWPC<br/>(solar indices)"]
+        NG3K["NG3K ADXO<br/>(DXpeditions)"]
+    end
+
+    subgraph SERVER["Server (docker compose, backend/)"]
+        COLLECTOR["collector<br/>(Python, asyncio)"]
+        VALKEY[("Valkey<br/>cache + streams")]
+        PG[("PostgreSQL 16<br/>holy_spots2")]
+        API["api<br/>(FastAPI + uvicorn)"]
+        NGINX["nginx<br/>(TLS termination)"]
+        MONITOR["monitor<br/>(Telegram alerts)"]
+    end
+
+    subgraph CLIENT["Operator's computer"]
+        BROWSER["Browser<br/>(React SPA)"]
+        CATSRV["Holy Cluster desktop app<br/>(catserver, Rust, :3000)"]
+        RADIO["Transceiver<br/>(via OmniRig / rigctld)"]
+        LOGGER["Logging software<br/>(WSJT-X UDP protocol)"]
+    end
+
+    TELNET --> COLLECTOR
+    POTA --> COLLECTOR
+    SOTA --> COLLECTOR
+    WWFF --> COLLECTOR
+    QRZ --> COLLECTOR
+    CTY --> COLLECTOR
+    NG3K --> COLLECTOR
+    NOAA --> API
+
+    COLLECTOR --> VALKEY
+    COLLECTOR --> PG
+    VALKEY --> API
+    PG --> API
+    API --> NGINX
+    MONITOR -.watches.-> API
+
+    NGINX <-->|"HTTPS + WSS"| BROWSER
+    NGINX <-->|"HTTPS + WSS"| CATSRV
+    CATSRV <-->|"localhost :3000<br/>proxied UI + /ws"| BROWSER
+    CATSRV <-->|"COM / TCP"| RADIO
+    CATSRV -->|"UDP status packet"| LOGGER
+```
+
+Two usage modes matter:
+
+1. **Plain web usage** — the browser talks to `https://holycluster.iarc.org` directly. Spots stream in over WebSocket; radio control is unavailable.
+2. **With the desktop app** — the user runs the catserver, which opens `http://127.0.0.1:3000` in their browser. The catserver **reverse-proxies the whole remote site** and additionally intercepts radio messages on the WebSocket, so the same web UI gains the ability to tune the local radio. (See [§6.1](#61-the-reverse-proxy-trick).)
+
+---
+
+## 3. Repository Layout
+
+```
+HolyCluster/
+├── backend/            # Python uv workspace + docker compose stack (the server)
+│   ├── api/            #   FastAPI web/WebSocket server
+│   ├── collectors/     #   Spot ingestion pipeline
+│   ├── monitor/        #   Health checks + Telegram alerts
+│   ├── shared/         #   DB models, geo/QRZ/CTY, settings (Python package)
+│   ├── migrations/     #   Alembic migrations
+│   ├── docker/         #   Dockerfiles for api/collector/monitor/migrate
+│   ├── infra/          #   nginx, postgres, valkey, certbot configs (AUTHORITATIVE)
+│   ├── docker-compose.yml
+│   ├── deploy.sh       #   Incremental deploy script (run by CI on the server)
+│   └── setup.sh        #   First-time TLS bootstrap
+├── ui/                 # React 18 + Vite SPA
+│   ├── src/components/ #   UI components (CanvasMap/ is the map engine)
+│   ├── src/hooks/      #   Context providers + data hooks
+│   ├── src/data/       #   Static reference data (bands, DXCC, zones…)
+│   ├── src/maps/       #   GeoJSON files
+│   └── tests/          #   Vitest tests
+├── catserver/          # Rust desktop CAT-control app (Windows MSI)
+│   ├── src/            #   axum server + rig backends
+│   └── wix/            #   MSI installer definition
+├── shared/             # band_plans.json — single source of band data for backend AND ui
+├── docs/               # User manual, runbooks, this document
+├── .github/workflows/  # backend.yml, ui.yml, catserver.yml
+├── nginx/, certbot/, postgres/, nginx-ui/   # ⚠ UNTRACKED local scratch (see gotchas)
+└── README.md           # ⚠ Partially stale (references removed ClientSideServer.py)
+```
+
+Key cross-cutting file: **`shared/band_plans.json`** — band edges and mode segments. The backend collector consumes it via a docker build context (`band_plans=../shared`); the UI imports it at build time with a relative path (`ui/src/data/band_plans.js`). Both sides must agree on band definitions, so this is the single source of truth. Moving it breaks both consumers.
+
+---
+
+## 4. The Backend (`backend/`)
+
+### 4.1 Workspace packages
+
+The backend is a **uv workspace** (Python ≥ 3.13) with four member packages:
+
+| Package | Path | Entry point | Role |
+|---|---|---|---|
+| `api` | `backend/api/` | `uvicorn api.main:app` (port 8000) | HTTP + WebSocket server, serves the SPA and the MSI |
+| `collectors` | `backend/collectors/` | `collector` script | Ingest, enrich, dedupe, persist spots |
+| `monitor` | `backend/monitor/` | `monitor` script | Synthetic checks + Telegram alerts |
+| `shared` | `backend/shared/` | `ensure_db` script | SQLModel models, geo/QRZ/CTY logic, pydantic settings |
+
+Everything runs from `docker compose up` in `backend/` (see [§7.1](#71-docker-compose-stack)). Lint is Ruff (line length 120). Tests exist under `api/tests/` and `collectors/tests/` but are **not currently run in CI**.
+
+### 4.2 The spot collection pipeline
+
+The collector (`collectors/src/collectors/main.py`) runs all sources as asyncio tasks feeding one `asyncio.Queue(maxsize=1000)`; a single consumer (`process_spots`) enriches and persists.
+
+```mermaid
+flowchart LR
+    subgraph SOURCES["Source tasks (asyncio)"]
+        T1["Telnet clients<br/>one per cluster server<br/>(telnet/client.py)"]
+        P1["POTA poller<br/>every 60s"]
+        S1["SOTA poller<br/>every 60s"]
+        W1["WWFF poller<br/>every 30s"]
+    end
+
+    Q{{"asyncio.Queue<br/>maxsize 1000"}}
+
+    subgraph CONSUMER["process_spots (single consumer)"]
+        DEDUP["Dedup check<br/>Valkey SET NX<br/>key = time:dx:freq:spotter<br/>TTL 60s"]
+        ENRICH["enrich_spot<br/>band/mode + geo + dxpedition"]
+        VALIDATE["validate<br/>callsign, band, locator"]
+    end
+
+    PG[("PostgreSQL<br/>holy_spots2")]
+    STREAM[("Valkey stream<br/>stream-api<br/>maxlen 10000")]
+    ARRIVALS[("Valkey stream<br/>stream-arrivals<br/>(source analytics)")]
+
+    T1 --> Q
+    P1 --> Q
+    S1 --> Q
+    W1 --> Q
+    P1 -.-> ARRIVALS
+    S1 -.-> ARRIVALS
+    W1 -.-> ARRIVALS
+    T1 -.-> ARRIVALS
+
+    Q --> DEDUP --> ENRICH --> VALIDATE
+    VALIDATE -->|"always"| PG
+    VALIDATE -->|"only if locator+band+mode present"| STREAM
+
+    STREAM -->|"consumer group api-group"| APIB["api: spots_broadcast_task"]
+    APIB -->|"WebSocket broadcast"| CLIENTS["All connected browsers"]
+```
+
+Source details:
+
+- **Telnet clusters** (`collectors/telnet/`): server list in `telnet_servers.csv` (DXUSA, WA9PIE-2, VE7CC, K7AR, AI9T, NC7J active). One task per server, exponential reconnect backoff (60 s → 24 h cap), regex line parsing, 60 s read timeout triggers a `help\n` keepalive. Login uses `USERNAME_FOR_TELNET_CLUSTERS`. Spotters `W3LPL` and `J9AQ` are hardcoded-banned (`client.py:132`).
+- **POTA / SOTA / WWFF** (`pota.py`, `sota.py`, `wwff.py`): JSON pollers sharing `utils.run_json_spot_collector`, which handles dedup, arrival recording, and error backoff (capped at 300 s).
+
+There is **no RBN or DXHeat collector** — the telnet clusters are the live feed.
+
+### 4.3 Spot enrichment
+
+```mermaid
+sequenceDiagram
+    participant C as process_spots
+    participant BP as band_plans.json
+    participant V as Valkey (geo cache)
+    participant Q as QRZ.com XML API
+    participant CTY as CTY file (in-process)
+    participant NG as NG3K feed (daily cache)
+    participant PG as PostgreSQL
+
+    C->>BP: find band + mode from frequency<br/>(mode also inferred from comment keywords)
+    Note over C: missing band → InvalidBandError → spot dropped
+    C->>V: GET geo:{callsign}
+    alt cache hit
+        V-->>C: locator, lat/lon, dxcc, zones
+    else cache miss
+        C->>Q: XML lookup (session key)
+        Q-->>C: grid locator, state, zones
+        alt QRZ has no grid
+            C->>CTY: prefix → country coordinates (fallback)
+        end
+        C->>CTY: prefix → DXCC code, continent (always)
+        C->>V: SET geo:{callsign} (TTL 3600s)
+    end
+    C->>NG: is_active_dxpedition(dx_callsign)? (prefix match)
+    C->>PG: INSERT INTO holy_spots2
+```
+
+Notes:
+
+- Both `spotter_callsign` and `dx_callsign` are geolocated (spot arcs need both endpoints).
+- A hardcoded override table for ~25 special callsigns/prefixes lives in `shared/src/shared/geo.py:33-60` — this is where you add fixes per the [`fix_missing_spot.md`](fix_missing_spot.md) runbook.
+- Spots resolving to the `AA00` (South Pole junk) locator are dropped.
+- The QRZ session key is refreshed hourly by the collector and stored in Valkey; the API's `/locator/{callsign}` endpoint depends on it and returns 503 if missing.
+
+### 4.4 Database schema
+
+PostgreSQL 16, accessed via **SQLModel** (SQLAlchemy 2.x) with **asyncpg**. Migrations via async Alembic (`backend/migrations/`); the one-shot `migrate` compose service runs `ensure_db && alembic upgrade head`.
+
+```mermaid
+erDiagram
+    HOLY_SPOTS2 {
+        int id PK
+        str time "UK(time,spotter,dx)"
+        int timestamp "epoch, indexed"
+        str spotter_callsign
+        str spotter_locator
+        float spotter_lat
+        float spotter_lon
+        int spotter_dxcc_code
+        str spotter_continent
+        int spotter_cq_zone
+        int spotter_itu_zone
+        str dx_callsign
+        str dx_locator
+        float dx_lat
+        float dx_lon
+        int dx_dxcc_code
+        str dx_continent
+        int dx_cq_zone
+        int dx_itu_zone
+        float frequency
+        str band
+        str mode
+        str mode_selection
+        str comment
+        bool is_dxpedition
+        str pota_reference
+        int sota_points
+    }
+    GEO_CACHE {
+        str callsign PK
+        str locator
+        float lat
+        float lon
+        int dxcc_code
+        str continent
+        datetime date_time
+    }
+    PROPAGATION_MEASUREMENTS {
+        int id PK
+        str metric "UK(metric,timestamp)"
+        int timestamp "indexed"
+        float value
+        datetime collected_at
+    }
+    SPOTS_WITH_ISSUES2 {
+        int id PK
+        str issues "⚠ write-dead: nothing inserts here"
+    }
+```
+
+Naming note: table names carry a `2` suffix (`holy_spots2`, `spots_with_issues2`) — an artifact of a past schema migration.
+
+⚠ **Two known data-lifecycle defects** (details in [IMPROVEMENTS.md](IMPROVEMENTS.md) #1):
+- `cleanup_postgres_tables.py` filters `HolySpot.date_time`, a column that doesn't exist — retention cleanup of the main spots table is broken.
+- Nothing writes to `spots_with_issues2`, yet the `fix_missing_spot.md` runbook and the `/spots_with_issues` endpoint assume it's populated.
+
+### 4.5 The API service
+
+FastAPI app (`api/src/api/main.py`, ~1100 lines) with GZip middleware and OpenAPI docs disabled. Startup lifespan opens the Valkey client and shared httpx client, ensures the CTY file, and spawns the propagation collector + spots broadcaster tasks. **It also serves the React SPA** (static `/assets` mount + `index.html` catch-all) and the catserver MSI — nginx in front is a pure TLS proxy.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/locator/{callsign}` | Callsign → locator/lat/lon (needs QRZ session; 503 if absent) |
+| GET | `/geocache/all`, `/geocache/{callsign}` | Geo cache dump / single record (⚠ `/all` is unbounded) |
+| GET | `/spots_with_issues` | Dump of `spots_with_issues2` (currently always empty) |
+| GET | `/propagation` | Latest solar indices (from memory) |
+| GET | `/propagation/history?start_time&end_time` | Index time-series (max 24 h window) |
+| GET | `/voacap?...` | VOACAP HF propagation grid (CPU-heavy, run in thread) |
+| GET | `/dxpeditions` | Active DXpeditions (from Valkey) |
+| GET | `/history?start_time&end_time` | Historical spots (max 24 h window) |
+| GET | `/cluster_stats?hours` | Source-overlap analytics from `stream-arrivals` |
+| GET | `/catserver/latest`, `/catserver/download` | Desktop app version + MSI download |
+| GET | `/health` | Liveness (used by compose healthcheck) |
+| GET | `/`, `/{path}` | SPA `index.html` catch-all |
+| WS | `/ws` | **Primary versioned protocol** (see below) |
+| WS | `/spots_ws`, `/submit_spot`, `/radio` | ⚠ Legacy endpoints, still live |
+
+### 4.6 WebSocket protocol
+
+One multiplexed socket, protocol version 1. Every message is JSON with `{"version": 1, "type": ...}`.
+
+```mermaid
+sequenceDiagram
+    participant B as Browser (useWs.jsx)
+    participant A as api /ws
+    participant S as Valkey stream-api
+
+    B->>A: {version:1, type:"spots", action:"initial"}
+    A-->>B: {type:"spots", spots:[...up to 500 recent...]}
+    loop live broadcast
+        S->>A: XREADGROUP api-group
+        A-->>B: {type:"spots", event:"update", spots:[...]}
+    end
+    Note over B,A: on reconnect: {action:"catch_up", last_time}
+
+    B->>A: {version:1, type:"submit", spotter_callsign, dx_callsign, freq, comment}
+    A->>A: telnet submit to dxc.ai9t.com:7300
+    A-->>B: {type:"submit", status:"success"|"failure", error_type}
+
+    B->>A: {version:1, type:"hunter", action:"start"/"add"/"finish", callsigns:[...]}
+    A-->>B: batch callsign resolutions (worker pool 4, batches of 50)
+
+    B->>A: {version:1, type:"radio", ...}
+    A-->>B: {type:"radio", status:"unavailable"}
+    Note over B,A: radio messages only mean something<br/>when the socket passes through catserver
+```
+
+The `radio` type is the interesting one: the backend always answers `unavailable`. When the user runs the desktop app, the **catserver sits between browser and backend** on this same socket and *intercepts* radio messages locally instead of forwarding them ([§6.3](#63-radio-control-message-flow)).
+
+### 4.7 Background jobs
+
+| Where | Job | Interval |
+|---|---|---|
+| collector | QRZ session key refresh | 1 h |
+| collector | NG3K DXpedition list refresh | 24 h (retry 10 min) |
+| collector | `trim_arrivals_stream` (7-day retention) | 1 h |
+| collector | POTA / SOTA / WWFF pollers | 60 / 60 / 30 s |
+| api | NOAA propagation fetch + persist | 1 h (retry 10 s) |
+| api | `spots_broadcast_task` (stream consumer) | continuous |
+| monitor | metric/heartbeat/WS/container checks | 60 s |
+| external | `cleanup_postgres` retention job | not in compose — external cron (⚠ and currently buggy) |
+
+### 4.8 Configuration
+
+All settings are **pydantic-settings** classes in `backend/shared/src/shared/settings.py`, reading `backend/.env`. A `Path("/.dockerenv").exists()` check auto-selects docker-internal vs localhost hosts/ports, so the same `.env` works inside and outside containers. Key variables (see `.env.example`): `POSTGRES_*`, `VALKEY_*` (incl. `VALKEY_GEO_EXPIRATION=3600`, `VALKEY_SPOT_EXPIRATION=60`), `QRZ_USER/PASSWORD/API_KEY`, `USERNAME_FOR_TELNET_CLUSTERS`, `UI_DIST_PATH`, `CATSERVER_MSI_DIR`, `LOG_DIR`, `DOMAIN`, `EMAIL`, monitor's `TELEGRAM_BOT_TOKEN/CHAT_ID`, `POSTGRES_DB_RETENTION_DAYS=14`.
+
+---
+
+## 5. The Frontend (`ui/`)
+
+### 5.1 Tech stack and entry flow
+
+React 18 (JSX, no TypeScript) + Vite 6 + Tailwind 3.4. Formatter/linter is **Biome** (4-space indent). Tests are **Vitest** + Testing Library. The map is **HTML5 Canvas + d3-geo** (not Leaflet). Notable deps: `react-use-websocket`, `solar-calculator` (day/night terminator), `maidenhead`, `idb` (IndexedDB), `adif-parser-ts`, `react-joyride` (tour), `@dnd-kit` (band reordering).
+
+In dev, `vite.config.js` proxies all API/WS routes to `holycluster-dev.iarc.org`, so `npm run dev` works without a local backend. A custom Vite plugin generates DXCC entity data at build time from CTY data.
+
+### 5.2 State management — the provider tree
+
+All global state is React Context — no Redux. **`ProfilesProvider` is the backbone**: nearly every persistent setting is a section of the "active profile" stored in localStorage.
+
+```mermaid
+flowchart TB
+    BR["BrowserRouter (main.jsx)"] --> WS["WsProvider<br/>single /ws socket, pub/sub by message type"]
+    WS --> PROF["ProfilesProvider<br/>localStorage 'profiles': multi-profile store"]
+    PROF --> COL["ColorsProvider<br/>themes Light/Dark/Blue/Gray + map themes"]
+    COL --> FIL["FiltersProvider<br/>band/mode/continent + callsign rules + shared-URL override"]
+    FIL --> SET["SettingsProvider<br/>= active profile's settings section"]
+    SET --> RAD["RadioProvider<br/>CAT status/freq/mode via 'radio' WS messages"]
+    RAD --> SPI["SpotInteractionProvider<br/>hovered/pinned spot, search"]
+    SPI --> MC["MainContainer"]
+    MC --> REST["RestDataProvider<br/>propagation + dxpeditions polling"]
+    REST --> SPOT["SpotDataProvider<br/>live WS spots | history spots → filtering"]
+    SPOT --> UI2["TopBar / LeftColumn / CanvasMap / SpotsTable / SidePanel / HistoryBar"]
+```
+
+⚠ Ordering is load-bearing: `SettingsProvider`, `FiltersProvider`, `ColorsProvider` all read from `ProfilesProvider` and throw if mounted outside it.
+
+Profile sections (defined in `utils/profile_data.js`): `settings`, `filters`, `callsign_filters`, `hunter`, `map_controls`, `map_view`, `table_sort`, `history`, `panels`, `radio`.
+
+### 5.3 Data flow into the UI
+
+```mermaid
+flowchart LR
+    subgraph TRANSPORT
+        WSOCK["WebSocket /ws<br/>(useWs: subscribe by type)"]
+        REST["REST fetch"]
+    end
+
+    subgraph DATA["Data hooks"]
+        SWS["useSpotWebSocket<br/>normalize, 1h trim,<br/>catch_up on reconnect"]
+        HIST["useHistorySpots<br/>IndexedDB gap-fill cache"]
+        FILT["useSpotFiltering<br/>time/band/mode/continent/<br/>callsign/hunter → slice(0,100)"]
+        RESTD["useRestData<br/>propagation + dxpeditions<br/>hourly polls"]
+        VOA["useVoacap<br/>350ms debounce + LRU"]
+        RADH["useRadio<br/>status/freq/mode"]
+    end
+
+    subgraph VIEW["Views"]
+        MAP["CanvasMap"]
+        TABLE["SpotsTable"]
+        BARS["PropagationBar / FrequencyBar"]
+        HP["HunterPanel / DXpeditions"]
+    end
+
+    WSOCK -->|"type: spots"| SWS
+    WSOCK -->|"type: radio"| RADH
+    REST -->|"/history"| HIST
+    REST -->|"/propagation /dxpeditions"| RESTD
+    REST -->|"/voacap"| VOA
+    SWS --> FILT
+    HIST --> FILT
+    FILT -->|"spots, new_spot_ids"| MAP
+    FILT --> TABLE
+    RESTD --> BARS
+    RESTD --> HP
+    VOA --> MAP
+    RADH --> BARS
+```
+
+Silent data limits worth knowing: live spots are trimmed to the **last hour**, and the filtered list is capped at **100 spots** (`useSpotFiltering.js`). Alerted spots bypass most filters. Messages sent while the socket isn't OPEN are silently dropped (`useWs.jsx:60`).
+
+### 5.4 The canvas map engine
+
+`components/CanvasMap/` renders with **four stacked canvases** and d3-geo projections — azimuthal equidistant ("radar" view centered on the user) or orthographic (globe):
+
+```mermaid
+flowchart TB
+    subgraph CANVASES["Stacked canvas layers (CanvasMap/index.jsx)"]
+        L1["1 · map_canvas — countries, borders, graticule,<br/>zones, Maidenhead grid, day/night terminator<br/>(draw_map.js, 1546 lines)"]
+        L2["2 · voacap_canvas — propagation heat overlay<br/>(draw_voacap.js)"]
+        L3["3 · spots_canvas — great-circle arcs, mode-shaped<br/>DX markers, azimuth line (draw_spots.js)<br/>redrawn per animation frame"]
+        L4["4 · shadow_canvas (offscreen) — pixel color<br/>hit-testing for click/hover (useMapHitTest)"]
+    end
+    PROJ["useMapProjection<br/>d3.geoAzimuthalEquidistant | geoOrthographic"]
+    GEST["useMapGestures (602 lines)<br/>pan/zoom/tap/context-menu → radius/center"]
+    REDRAW["useMapRedraw<br/>3 effects + rAF loop (only when alerted spots animate)<br/>+ minute tick for the moving terminator"]
+    RSR["render_state_ref (mutable ref)<br/>latest props for the rAF loop without re-subscribing"]
+
+    PROJ --> L1 & L3
+    GEST --> PROJ
+    REDRAW --> CANVASES
+    RSR --> REDRAW
+```
+
+The day/night terminator computes the solar antipode with `solar-calculator` and draws a 90°-radius `d3.geoCircle` at 30% alpha; a minute-tick effect keeps it moving. The `render_state_ref` pattern deliberately bypasses React re-renders for the animation loop — treat it carefully (stale-closure territory).
+
+### 5.5 Persistence — profiles in localStorage
+
+- **`"profiles"`** — the entire multi-profile store; every settings write re-serializes and sanitizes it. Legacy standalone keys are migrated on first load.
+- **IndexedDB** (`utils/spot_cache_db.js`) — history-spot interval cache with gap-fill and idle-time eviction every 3 h.
+- **URL param** — filters can be shared as links; a shared filter temporarily overrides profile filters until saved.
+- Misc keys: `"colors"` + `"dev_mode"` (dev-mode theme editor), `"active_view"`, `"mobile_tab"`, `"first_launch"`, `"last_release"`, tour-completion.
+
+There is **no server-side account or sync** — profiles are exported/imported as JSON files in Settings.
+
+### 5.6 Major features map
+
+| Feature | Key files | Notes |
+|---|---|---|
+| Spots table | `SpotsTable.jsx` (908 lines) | Sortable, row click tunes radio, context menu adds filters |
+| Filters | `useFilters.jsx`, `FilterModal.jsx` | Bands/modes/continents/callsign rules; shareable URLs; 3-state zone cycle |
+| Settings | `settings/Settings.jsx` + tabs | temp-copy edit, committed on save |
+| Hunter panel | `HunterPanel.jsx` (729 lines), `hunter_adif*` | ADIF import in a Web Worker (50 MB limit); flags "needed" spots |
+| DXpeditions | `DXpeditions.jsx` | From NG3K via backend |
+| Propagation | `PropagationBar.jsx` | SFI / A / K indices |
+| VOACAP overlay | `useVoacap.jsx`, `draw_voacap.js` | ⚠ dev-mode gated |
+| History playback | `history/HistoryBar.jsx` | ⚠ dev-mode gated |
+| Guided tour | `tour/` (react-joyride) | Targets `data-tour` attributes |
+| Radio CAT | `useRadio.jsx` | Version-gated features by parsed catserver version |
+| Submit spot | `SubmitSpot.jsx` | Via shared `/ws`; contains a dead legacy socket path |
+
+---
+
+## 6. The CAT Server (`catserver/`)
+
+A small Rust desktop app (product name **"Holy Cluster"**, `HolyCluster.exe`) that operators install on Windows. It bridges the *remote* web UI to the *local* radio.
+
+### 6.1 The reverse-proxy trick
+
+A page served from `https://holycluster.iarc.org` cannot open a WebSocket to `ws://localhost` hardware bridges reliably (mixed content, certificates). The catserver solves this by **serving the whole site itself**:
+
+```mermaid
+flowchart LR
+    subgraph LOCAL["Operator's PC"]
+        B["Browser at<br/>http://127.0.0.1:3000"]
+        CS["catserver (axum server :3000)"]
+        R["Radio<br/>OmniRig (Windows COM)<br/>or rigctld :4532 (hamlib)"]
+        LOG["Logger (WSJT-X UDP)"]
+    end
+    REMOTE["holycluster.iarc.org<br/>(or holycluster-dev with --dev-server)"]
+
+    B -->|"all HTTP requests"| CS
+    CS -->|"reverse-proxies pages,<br/>assets, API"| REMOTE
+    B <-->|"/ws (one socket)"| CS
+    CS <-->|"non-radio messages<br/>forwarded upstream"| REMOTE
+    CS <-->|"type: radio messages<br/>handled locally"| R
+    CS -->|"HighlightSpot →<br/>WSJT-X status packet"| LOG
+```
+
+On launch, `main.rs` opens the default browser at `http://127.0.0.1:3000`. Every HTTP request is proxied to the remote site — except the `/ws` WebSocket, where catserver splits traffic: messages with `version==1 && type=="radio"` are handled locally against the rig; everything else is forwarded to the real backend. The UI therefore needs no special "local mode" — the same `radio` messages that the plain backend answers with `unavailable` suddenly start working.
+
+A single-instance guard makes a second launch POST `/open` to the already-running instance instead of starting again. `--local-ui` serves a local `ui/dist` instead of proxying (frontend dev against a real radio).
+
+### 6.2 Modules and rig backends
+
+| Module | Role |
+|---|---|
+| `main.rs` | Arg parsing, single-instance guard, backend selection, tray icon spawn |
+| `server.rs` | axum HTTP/WS server on `0.0.0.0:3000`, proxy, radio command loop |
+| `rig.rs` | `Radio` trait + thread-safe `AnyRadio` wrapper (with lock-poison recovery) |
+| `omnirig.rs` | **Windows**: OmniRig via COM/IDispatch (winsafe) |
+| `rigctld.rs` | **non-Windows**: TCP text protocol to hamlib `rigctld` at `localhost:4532` |
+| `dummy.rs` | Fake radio (`--dummy`) for development |
+| `freq.rs` | `Freq` newtype (hertz as `u32`) |
+| `tray_icon.rs` | Windows system-tray icon (Open / Quit) |
+| `reporting.rs` | WSJT-X-compatible UDP status packet for logger integration |
+| `utils.rs` | axum ↔ tungstenite WS message conversion |
+
+Backend selection is compile-time by OS (`#[cfg(windows)]` → OmniRig, else rigctld), with `--dummy` as a runtime override. Both real backends auto-reinit after 5 consecutive failures. If OmniRig isn't installed, the app opens the site's `/omnirig-error` page and exits.
+
+### 6.3 Radio control message flow
+
+```mermaid
+sequenceDiagram
+    participant UI as Web UI (useRadio.jsx)
+    participant CS as catserver /ws
+    participant RIG as OmniRig / rigctld
+    participant LOG as Logger (UDP)
+
+    Note over UI,CS: user clicks a spot row
+    UI->>CS: {version:1, type:"radio", action:"SetModeAndFreq", mode:"CW", freq: 14025.0}
+    CS->>CS: derive USB/LSB from band (is_upper_sideband)
+    CS->>RIG: set frequency + mode (Slot A)
+    UI->>CS: {action:"SetRig", rig: 2}
+    CS->>RIG: switch to Rig 2
+    UI->>CS: {action:"HighlightSpot", dx_callsign, freq, mode, udp_port}
+    CS->>LOG: WSJT-X status UDP packet → 127.0.0.1:udp_port
+
+    loop every 500ms (only on change)
+        CS->>RIG: poll status/freq/mode
+        CS-->>UI: {version:1, type:"radio", event:"status",<br/>freq, mode, status, current_rig, catserver_version}
+    end
+```
+
+The `catserver_version` in status messages powers the UI's update nudge: the UI fetches `/catserver/latest` from the backend and compares — if the served MSI is newer, it shows "new version available".
+
+### 6.4 Packaging and distribution
+
+```mermaid
+flowchart LR
+    DEV["push to dev /<br/>tag catserver-v*"] --> GH["GitHub Actions (catserver.yml)<br/>runs in ghcr.io/iarc-il/catserver-ci<br/>(Rust + mingw + Wine + WiX 5)"]
+    GH --> FMT["cargo fmt + clippy -D warnings"]
+    FMT --> BUILD["cargo build --release<br/>target x86_64-pc-windows-gnu"]
+    BUILD --> MSI["build_msi.sh → WiX → HolyCluster .msi"]
+    MSI --> PUB["publish.sh: scp to /opt/msi on<br/>dev (branch) or prod (tag) server<br/>+ update 'latest' file"]
+    PUB --> SERVE["api serves /catserver/download<br/>UI links to it"]
+```
+
+Notables: the Windows MSI is cross-built **on Linux** (mingw + Wine + WiX 5.0.2). `build.rs` derives the version from `git describe --match catserver-v*` and **panics if no such tag is reachable** — shallow clones without tags fail to build. Dev builds bake `--dev-server` into the shortcut so they point at the dev site.
+
+---
+
+## 7. Infrastructure & Deployment
+
+### 7.1 Docker Compose stack
+
+Single compose file: `backend/docker-compose.yml`. Default bridge network; services address each other by name. Env from `backend/.env`.
+
+```mermaid
+flowchart TB
+    subgraph EDGE["Edge"]
+        NG["nginx :80 :443 :9999<br/>TLS termination, envsubst template"]
+        CB["certbot<br/>renew loop every 6h"]
+    end
+    subgraph APP["Application"]
+        API["api :8000 (expose)<br/>FastAPI — serves SPA + API + MSI"]
+        COLL["collector<br/>spot ingestion"]
+        MON["monitor<br/>docker.sock + Telegram"]
+    end
+    subgraph DATA["Data"]
+        PGS[("postgres 16.9<br/>127.0.0.1:15432<br/>bind mount infra/postgres/data")]
+        VK[("valkey 8.1.4<br/>127.0.0.1:6379<br/>⚠ NO persistence volume")]
+    end
+    MIG["migrate (one-shot)<br/>ensure_db + alembic upgrade head"]
+    NUI["nginx_ui :8080/:8443<br/>(dev profile only)"]
+
+    NG -->|"proxy / → api:8000"| API
+    CB <-->|"shared certbot volumes"| NG
+    MIG --> PGS
+    API --> VK & PGS
+    COLL --> VK & PGS
+    MON -.->|"docker ps via socket"| APP
+    API -. "depends: migrate done, valkey healthy" .-> MIG
+    COLL -. "depends: migrate done, valkey healthy" .-> MIG
+    NUI -.->|"manages nginx config"| NG
+```
+
+Mounted from the host into `api`: the UI dist (`${UI_DIST_PATH}`, rsynced by CI), the MSI dir (`${CATSERVER_MSI_DIR}`, scp'd by CI), and logs. The `monitor` and `nginx_ui` containers mount `/var/run/docker.sock` (effectively root-on-host — known tradeoff).
+
+### 7.2 Nginx routing and TLS
+
+The **authoritative config is `backend/infra/nginx/nginx.conf.template`** — rendered at container start with `envsubst '${DOMAIN}'`. (The committed `nginx.conf` next to it is a stale render; editing it does nothing.)
+
+Server blocks: `:80` → ACME challenge + redirect to HTTPS; `:443` → proxy everything to `api:8000` with WebSocket upgrade headers; `:9999` → nginx-ui admin (proxy commented out in the template); `:3000` → passthrough to the docker host (Grafana lives on the host).
+
+```mermaid
+sequenceDiagram
+    participant CB as certbot container
+    participant FS as shared volume<br/>infra/certbot/conf
+    participant NG as nginx container
+
+    loop every 6h
+        CB->>FS: certbot renew (webroot challenge via :80)
+    end
+    loop every 6h (separate loop in nginx compose command)
+        NG->>FS: stat fullchain.pem mtime
+        alt mtime changed
+            NG->>NG: nginx -s reload
+        end
+    end
+    Note over NG: mtime-polling avoids reload churn that would<br/>kill long-lived WebSocket connections.<br/>⚠ If the compose command is ever reverted to the<br/>Dockerfile CMD, renewed certs are silently never loaded.
+```
+
+First-time issuance is manual via `backend/setup.sh` (temporary self-signed cert → start stack → real `certbot certonly` → reload).
+
+### 7.3 CI/CD pipelines
+
+All three workflows deploy over SSH: pushes to `dev` → dev server; version tags → prod server.
+
+```mermaid
+flowchart TB
+    subgraph BE["backend.yml — paths: backend/**"]
+        B1["ruff check + format check<br/>⚠ NO tests run"] --> B2["SSH to server:<br/>bash deploy.sh &lt;ref&gt;"]
+        B2 --> B3["deploy.sh: git reset --hard,<br/>diff-map changed files → services,<br/>rebuild only affected, migrate if needed"]
+    end
+    subgraph FE["ui.yml — paths: ui/**"]
+        U1["npm ci → biome check → vite build<br/>⚠ vitest NOT run"] --> U2["rsync ui/dist → ${DEPLOY_PATH}<br/>(bind-mounted into api container)"]
+    end
+    subgraph CS["catserver.yml — paths: catserver/**"]
+        C1["fmt + clippy + release build + MSI"] --> C2["scp MSI → /opt/msi + latest file"]
+    end
+    TRIG["push dev → dev server<br/>tag backend-v* / v* / catserver-v* → prod"] --> BE & FE & CS
+```
+
+`deploy.sh` is the clever part: it diffs the incoming ref against the current HEAD, maps changed paths to compose services (e.g. `api/**` → api, `shared/**` → everything + migrations), stops `monitor` first to avoid alert flapping, rebuilds only what changed, and restarts nginx last. It also `git reset --hard`s the server working tree — never hand-edit on the server.
+
+### 7.4 Production topology
+
+```mermaid
+flowchart TB
+    subgraph PROD["Prod server — holycluster.iarc.org"]
+        REPO1["repo checkout at REPO_ROOT_PROD<br/>backend/ compose stack"]
+        HOSTP["host: /opt/msi (MSIs) · UI dist dir · Grafana :3000"]
+    end
+    subgraph DEVS["Dev server — holycluster-dev.iarc.org"]
+        REPO2["repo checkout at REPO_ROOT_DEV<br/>same stack, dev branch"]
+    end
+    GH2["GitHub Actions"] -->|"branch dev"| DEVS
+    GH2 -->|"tags"| PROD
+    USERS["Operators"] --> PROD
+    TESTERS["Team / catserver dev builds"] --> DEVS
+```
+
+The UI dev proxy and catserver `--dev-server` flag both target the dev domain, so frontend and desktop development run against live dev data.
+
+---
+
+## 8. Development Workflow
+
+**Frontend** (no local backend needed — proxies to dev server):
+```bash
+cd ui
+npm install
+npm run dev        # Vite dev server, proxies API/WS to holycluster-dev.iarc.org
+npm run check      # biome + vitest
+```
+
+**Backend** (full stack):
+```bash
+cd backend
+cp .env.example .env   # fill in secrets (QRZ creds, telnet username, paths)
+docker compose up      # postgres, valkey, migrate, collector, api, monitor, nginx
+# API on http://localhost:8000 (through compose), postgres on 127.0.0.1:15432
+uv run pytest          # run package tests (pytest not in deps — use uvx pytest if needed)
+```
+
+**Catserver** (on any OS with a dummy radio):
+```bash
+cd catserver
+cargo run -- --dummy            # local server :3000, fake radio
+cargo run -- --dummy --local-ui # serve local ui/dist instead of proxying
+```
+Note: a full build needs a reachable `catserver-v*` git tag (`git fetch --tags`), or `build.rs` panics.
+
+**Releases:** merge to `dev` → auto-deploy to dev server. Tag `backend-vX`, `vX` (UI), or `catserver-vX` → deploy to prod.
+
+---
+
+## 9. Maintainer Gotchas
+
+The condensed list of things most likely to bite you — the top items are expanded into the prioritized backlog in [IMPROVEMENTS.md](IMPROVEMENTS.md).
+
+1. **Retention cleanup is broken** — `cleanup_postgres_tables.py` references a nonexistent `HolySpot.date_time`; `holy_spots2` grows unbounded.
+2. **The `fix_missing_spot.md` runbook is partly obsolete** — nothing writes to `spots_with_issues2` anymore.
+3. **CI runs zero tests** — backend pytest suites and UI vitest suites exist but only linters gate deploys.
+4. **Valkey has no persistence** — restart loses geo cache, dedup keys, streams, and the QRZ session key (API `/locator` 503s until the collector refreshes it).
+5. **Edit `nginx.conf.template`, not `nginx.conf`** — only the template is rendered at runtime.
+6. **Legacy protocol duplication** — `/spots_ws`, `/submit_spot`, `/radio` (backend), `/radio` + dual message enums (catserver), dead submit path (UI) all still exist alongside the v1 `/ws` protocol; both broadcast sets must be kept in sync.
+7. **catserver binds `0.0.0.0:3000`** — the local bridge (and radio control) is reachable from the LAN.
+8. **QRZ password goes into a URL query string** (`shared/qrz.py`) — shows up wherever URLs are logged.
+9. **Untracked shadow trees** at repo root (`nginx/`, `certbot/`, `postgres/`, `nginx-ui/`) are local scratch; the authoritative infra lives in `backend/infra/`. Live PGDATA sits inside the repo tree as a bind mount.
+10. **Stale README** — `ClientSideServer.py` and the pip install flow no longer exist; the Rust catserver replaced them.
+11. **Timezone mix** — `HolySpot.time` derives from local time (containers pin `TZ=Asia/Jerusalem`) while `timestamp` is epoch; be careful comparing.
+12. **Frontend hot spots** — `draw_map.js` (1546 lines), `SpotsTable.jsx` (908), `MapControls.jsx` (774), `useMapGestures.js` (602) carry most of the complexity and little test coverage; the canvas rAF loop reads a mutable `render_state_ref` outside React's model.
+13. **Silent UI limits** — spots trimmed to 1 hour and capped at 100 after filtering; WS sends dropped when the socket isn't open; VOACAP and history playback are dev-mode gated.
+14. **Version-gated features** — spot highlight (UDP) only fires when catserver version > 1.1.0.0; version parsing is regex-based on git-describe output.

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -1,0 +1,301 @@
+# HolyCluster — Improvement Backlog
+
+> Ten improvements, **ordered by importance**, based on a full-repo architecture review (see [`ARCHITECTURE.md`](ARCHITECTURE.md)).
+> Companion file: [`improvements.html`](improvements.html) (same content, rendered diagrams).
+>
+> Every finding below was verified against the code; file/line references point at the evidence.
+
+## Priority Overview
+
+```mermaid
+quadrantChart
+    title Impact vs. Effort
+    x-axis Low Effort --> High Effort
+    y-axis Low Impact --> High Impact
+    quadrant-1 Plan carefully
+    quadrant-2 Do first
+    quadrant-3 Nice to have
+    quadrant-4 Schedule
+    "1 Fix data retention": [0.2, 0.95]
+    "2 Tests in CI": [0.25, 0.85]
+    "3 Security hardening": [0.3, 0.8]
+    "4 Valkey persistence": [0.2, 0.65]
+    "5 DB backups": [0.35, 0.75]
+    "6 Retire legacy WS": [0.55, 0.55]
+    "7 Repo/docs hygiene": [0.3, 0.45]
+    "8 API limits + logs": [0.2, 0.4]
+    "9 Split draw_map.js": [0.7, 0.5]
+    "10 UTC timestamps": [0.5, 0.4]
+```
+
+| # | Improvement | Category | Effort | Risk if ignored |
+|---|---|---|---|---|
+| 1 | Fix broken data-retention & issues-table pipeline | Data integrity | S | Unbounded DB growth; broken ops runbook |
+| 2 | Run the existing test suites in CI | Quality gate | S | Regressions ship straight to prod |
+| 3 | Security hardening (catserver bind, QRZ creds) | Security | S–M | LAN radio takeover; credential leak via logs |
+| 4 | Enable Valkey persistence & graceful degradation | Resilience | S | Feature outages after every restart |
+| 5 | Automated PostgreSQL backups (+ move PGDATA) | Disaster recovery | M | Total data loss is one `rm -rf` away |
+| 6 | Retire the legacy WebSocket protocols | Simplification | M | Dual code paths drift; double maintenance |
+| 7 | Repository & documentation hygiene | Onboarding | S | New engineers follow stale README into dead ends |
+| 8 | Bound the unbounded API endpoints, drop debug logs | Robustness | S | Memory spikes; noisy logs |
+| 9 | Break up the frontend monoliths, test the map | Maintainability | L | Map changes stay high-risk and untestable |
+| 10 | Unify timestamps on UTC | Correctness | M | Subtle time-window bugs, DST edge cases |
+
+Effort: S = hours, M = days, L = week+.
+
+---
+
+## 1. Fix the broken data-retention & issues-table pipeline
+
+**Category: data integrity · Effort: S · The only known *actively broken* production defect.**
+
+Two related failures in the spot data lifecycle:
+
+- **The retention job crashes on the main table.** `backend/collectors/src/collectors/db/cleanup_postgres_tables.py:40` deletes rows `where(model.date_time < cutoff)` for both models, but `HolySpot` has no `date_time` column (only `time` and `timestamp` — `backend/shared/src/shared/db.py:35-72`). Cleanup of `holy_spots2` raises `AttributeError`, so the intended 14-day retention (`POSTGRES_DB_RETENTION_DAYS`) never happens and the table grows without bound. The job isn't in docker-compose either — confirm the external cron actually exists on both servers.
+- **The issues table is write-dead.** The `fix_missing_spot.md` runbook and the `/spots_with_issues` endpoint both assume `spots_with_issues2` is populated, but no code inserts into it — the collector silently drops problematic spots (`collectors/main.py:178-207`). The team's own debugging procedure no longer works.
+
+```mermaid
+flowchart LR
+    subgraph TODAY["Today"]
+        A1["spot fails enrichment"] -->|"dropped silently"| X1["∅ (no trace)"]
+        B1["cleanup cron"] -->|"AttributeError on<br/>HolySpot.date_time"| X2["holy_spots2 grows forever"]
+    end
+    subgraph FIXED["Fixed"]
+        A2["spot fails enrichment"] -->|"INSERT with issue reason"| T2[("spots_with_issues2")]
+        B2["cleanup cron<br/>(runs in compose or documented cron)"] -->|"WHERE timestamp < cutoff"| T3[("holy_spots2 ≤ 14 days")]
+        T2 -->|"powers fix_missing_spot.md runbook"| OPS["ops debugging"]
+    end
+```
+
+**Do:** (a) filter on `HolySpot.timestamp` (epoch int) instead of `date_time`; (b) re-add the insert into `SpotsWithIssues` where enrichment fails, with the failure reason; (c) schedule `cleanup_postgres` explicitly (a compose service with a loop, or a documented cron) and add a test for it; (d) update `fix_missing_spot.md` to match reality.
+
+---
+
+## 2. Run the existing test suites in CI
+
+**Category: quality gate · Effort: S · Highest leverage-per-hour in the repo.**
+
+Both test suites already exist — CI just never runs them. A push to `dev` **deploys to the dev server** having only passed linters; a tag deploys to prod the same way.
+
+- `backend.yml` runs only `ruff check` + `ruff format --check`; the pytest suites in `backend/api/tests/` (WebSocket protocol, VOACAP, propagation) and `backend/collectors/tests/` (parsers, enrichers, geo) are skipped. `pytest` isn't even a declared dev dependency.
+- `ui.yml` runs `biome check` + `vite build`, but not `vitest` — despite 23 test files in `ui/tests/` and an existing `npm run check` script that does exactly lint+test.
+
+```mermaid
+flowchart LR
+    subgraph NOW["Today"]
+        P1["push"] --> L1["lint only"] --> D1["deploy 🚢"]
+    end
+    subgraph TARGET["Target"]
+        P2["push"] --> L2["lint"] --> T2["backend: uv run pytest<br/>ui: vitest run"] --> D2["deploy 🚢"]
+        T2 -->|"fail"| STOP["❌ blocked before the server"]
+    end
+```
+
+**Do:** add `pytest` (+ `pytest-asyncio`) to the backend dev dependencies and a `uv run pytest` step to `backend.yml`; change `ui.yml` to `npm run check` (or add `npx vitest run`). Then grow coverage where it hurts most: the collector enrichment path and the `/ws` protocol.
+
+---
+
+## 3. Security hardening — catserver bind address & QRZ credentials
+
+**Category: security · Effort: S–M.**
+
+Three independent findings, ordered by severity:
+
+1. **catserver listens on `0.0.0.0:3000`** (`catserver/src/server.rs:119`), not `127.0.0.1`. Anyone on the operator's LAN (or a hostile Wi-Fi network) can open the proxied UI, drive the WebSocket, and **transmit-tune the user's radio** — and reach the `/exit` endpoint to kill the app. The design only ever needs localhost (the browser it launches is local).
+2. **The QRZ password travels in a URL query string** (`backend/shared/src/shared/qrz.py:93`). Query strings end up in HTTP client logs, proxies, and exception traces. QRZ's XML API accepts POST form data; at minimum, make sure the URL never reaches a logger.
+3. **Docker socket mounts** (`monitor`, `nginx_ui` services) are root-on-host equivalents. `nginx_ui` is dev-profile-only — good — but `monitor` runs in prod; consider a socket proxy (e.g. read-only `docker ps` filtering) or at least document the tradeoff.
+
+```mermaid
+flowchart TB
+    subgraph LAN["Operator's home network — today"]
+        EVIL["Any LAN device"] -->|"http://operator-pc:3000"| CS["catserver 0.0.0.0:3000"]
+        CS -->|"SetModeAndFreq"| RADIO["radio transmitter"]
+        CS -->|"POST /exit"| KILL["app killed"]
+    end
+    subgraph FIXEDNET["Fixed"]
+        B2["local browser only"] -->|"127.0.0.1:3000"| CS2["catserver bound to loopback"]
+    end
+```
+
+**Do:** bind `127.0.0.1` (keep an opt-in `--bind` flag for the rare remote-desktop setup); move QRZ auth out of the query string or guarantee URL redaction in logs; review docker-socket exposure. Also note `nginx-ui/app.ini` holds plaintext secrets in the working tree (gitignored, but visible to anyone with tree access).
+
+---
+
+## 4. Enable Valkey persistence & graceful degradation
+
+**Category: resilience · Effort: S.**
+
+The Valkey service has its persistence volume **commented out** (`backend/docker-compose.yml:32-34`). Every restart (deploy, crash, host reboot) loses:
+
+| Lost state | Consequence |
+|---|---|
+| `qrz:session_key` | `/locator` returns **503** until the collector's hourly refresh runs |
+| geo cache | QRZ hammered with re-lookups; slower enrichment for up to 1 h |
+| dedup keys | brief duplicate-spot window across sources |
+| `stream-api` + consumer group | broadcast gap; clients rely on `catch_up` |
+| `stream-arrivals` | cluster-stats history truncated |
+| `dxpeditions:active` | `/dxpeditions` empty until the daily refresh |
+
+```mermaid
+sequenceDiagram
+    participant D as deploy / restart
+    participant V as Valkey (no AOF/RDB)
+    participant A as api
+    participant C as collector
+    D->>V: container restarts — all keys gone
+    A->>V: GET qrz:session_key
+    V-->>A: nil
+    A-->>A: /locator → 503 (up to 1h)
+    C->>C: hourly qrz_session_key_refresh finally repopulates
+    Note over D,C: With AOF everysec (or save + volume),<br/>none of this happens.
+```
+
+**Do:** uncomment the data volume and enable `appendonly yes` (AOF everysec) in `infra/valkey/`; independently, make the API request a QRZ session itself when the key is missing instead of 503-ing until the collector's next cycle.
+
+---
+
+## 5. Automated PostgreSQL backups — and move PGDATA out of the repo tree
+
+**Category: disaster recovery · Effort: M.**
+
+There is **no backup mechanism anywhere in the repo**, and the live database files sit *inside the git working tree* as a bind mount (`backend/infra/postgres/data/`). The deploy script runs `git reset --hard` in that same tree on every deploy; gitignore is the only thing separating a routine deploy from data loss. `docs/fix_missing_spot.md` even documents `TRUNCATE TABLE geo_cache;` as a casual ops step — with no restore path if the wrong table is truncated.
+
+```mermaid
+flowchart LR
+    subgraph TODAY["Today"]
+        REPO["git working tree<br/>backend/infra/postgres/data ⚠"]
+        DEPLOY["deploy.sh: git reset --hard"] -.->|"one .gitignore mistake away"| REPO
+        REPO -->|"no dumps, no WAL archive"| NORESTORE["❌ no restore path"]
+    end
+    subgraph TARGET["Target"]
+        VOL[("named docker volume<br/>outside the repo")]
+        CRON["nightly pg_dump container"] --> LOCALD["local dumps (7d)"]
+        LOCALD --> OFFSITE["off-site copy (S3/rsync)"]
+        RESTORE["documented + rehearsed restore"] --> VOL
+    end
+```
+
+**Do:** add a nightly `pg_dump` sidecar (or host cron) with rotation and an off-site copy; move PGDATA to a named volume or a path outside the repo; write a short `docs/restore.md` and actually rehearse it once. Postgres is the only stateful store that can't be regenerated — spots history is irreplaceable.
+
+---
+
+## 6. Retire the legacy WebSocket protocols
+
+**Category: simplification · Effort: M (needs a client-usage measurement first).**
+
+The versioned `/ws` protocol (v1) replaced older endpoints, but the old ones were never removed. Today **four parallel paths** exist across three codebases:
+
+```mermaid
+flowchart TB
+    subgraph BACKEND["backend api"]
+        WS1["/ws (v1, multiplexed) ✅"]
+        LEG1["/spots_ws (unversioned) ⚠"]
+        LEG2["/submit_spot ⚠"]
+        LEG3["/radio (always 'unavailable') ⚠"]
+        BC["broadcast_spots must feed BOTH<br/>active_connections + active_ws_spot_connections"]
+    end
+    subgraph CATS["catserver"]
+        CWS["/ws unified handler ✅"]
+        CLEG["/radio legacy handler +<br/>duplicate ClientMessage/WsRadioClientMessage enums ⚠"]
+    end
+    subgraph UI["ui"]
+        UWS["useWs → /ws ✅"]
+        ULEG["SubmitSpot.jsx:38 dead<br/>connect_to_submit_spot_endpoint ⚠"]
+    end
+    WS1 --- CWS --- UWS
+```
+
+Every spots broadcast is duplicated to two connection sets (`api/main.py:110-115`); catserver maintains two near-identical command enums (`server.rs:568-629`); the UI ships dead socket code and the Vite proxy still routes three legacy WS paths. Old catserver installations are the main reason the legacy endpoints survive — which is exactly why the catserver auto-update nudge matters.
+
+**Do:** log per-endpoint connection counts for a few weeks; then delete the UI dead path (free), remove catserver's `/radio` handler and duplicate enum, and finally remove the backend legacy endpoints (or return a "please update" close code). End state: one protocol, one broadcast set, one enum.
+
+---
+
+## 7. Repository & documentation hygiene
+
+**Category: onboarding · Effort: S.**
+
+Individually small, collectively the first impression every new engineer gets:
+
+- **README is wrong.** It instructs `pip install -e '.[omnirig]'` and `python src/ClientSideServer.py` (`README.md:53,58`) — neither exists; the Rust catserver replaced them, and the backend moved to `uv` + docker compose long ago.
+- **~120 MB of log files at repo root** (`compose_logs_int_3.txt` 41 MB, `compose_logs_int_4.txt` 79 MB) — untracked but not gitignored, so they pollute `git status` forever.
+- **Shadow infra trees** at the root (`nginx/`, `certbot/`, `postgres/`, `nginx-ui/`) shadow the authoritative `backend/infra/` — a classic edit-the-wrong-file trap.
+- **`nginx.conf` vs `nginx.conf.template` drift**: only the template is rendered at runtime; the committed rendered copy differs (the :9999 `proxy_pass` line) and misleads.
+- Minor: leftover `logger.info("test")` debug lines (see #8), the WiX installer writes its registry keypath under boilerplate `Software\MyCompany\MyApp` (`catserver/wix/main.wxs:122-124`), `publish.sh:22` `exit1` typo.
+
+**Do:** rewrite the README around the three real components (a condensed version of `ARCHITECTURE.md` §8); delete the logs and gitignore `compose_logs*`; add a root-README note (or `.md` marker files) pointing from the shadow trees to `backend/infra/`; delete the stale rendered `nginx.conf` or regenerate it in CI; fix the WiX keypath.
+
+---
+
+## 8. Bound the unbounded API endpoints & remove debug leftovers
+
+**Category: robustness · Effort: S.**
+
+- `GET /geocache/all` (`api/main.py:594`) serializes the **entire** `geo_cache` table — tens of thousands of rows, no limit, no pagination — into memory per request. An accidental refresh-loop or a crawler can spike API memory/CPU.
+- `GET /spots_with_issues` (`api/main.py:612`) is the same pattern (currently returns `[]` only because of defect #1 — fixing #1 makes this one unbounded too).
+- `/history` contains leftover debug logging: `logger.info("test 1s")`, `logger.info("test")` (`api/main.py:1068,1071`).
+- No rate limiting exists anywhere; nginx would be the natural place for a basic `limit_req` on the expensive endpoints (`/voacap`, `/history`).
+
+**Do:** add `limit`/`offset` (with a sane default and max) to both dump endpoints — or restrict them to internal use; delete the debug lines; add a modest nginx `limit_req` zone for `/voacap` and `/history`.
+
+---
+
+## 9. Break up the frontend monoliths & test the map engine
+
+**Category: maintainability · Effort: L.**
+
+The map — the product's core — is concentrated in a handful of giant, effectively untested files:
+
+```mermaid
+flowchart LR
+    subgraph HOT["Complexity hot spots (lines)"]
+        DM["draw_map.js — 1546"]
+        ST["SpotsTable.jsx — 908"]
+        MC["MapControls.jsx — 774"]
+        HP["HunterPanel.jsx — 729"]
+        MG["useMapGestures.js — 602"]
+    end
+    TESTS["ui/tests/ — 23 files<br/>cover data/utils + a few components<br/>❌ zero coverage of canvas drawing,<br/>projections, gestures, hit-testing"]
+    HOT -.->|"every change is a<br/>manual-QA-only change"| RISK["high regression risk"]
+```
+
+`draw_map.js` alone contains country fills, adaptive Maidenhead grid + labels, CQ/ITU zones, DXCC strokes, the equator, and the day/night terminator. The animation loop reads a mutable `render_state_ref` outside React's model — correct today, but a stale-closure magnet for anyone editing `useMapRedraw.js`.
+
+**Do (incrementally, not a rewrite):** split `draw_map.js` by layer (`draw_countries.js`, `draw_grid.js`, `draw_zones.js`, `draw_night.js`) — the seams already exist as top-level functions; extract the pure geometry/label-placement helpers and unit-test those (no canvas needed); add a couple of golden-image canvas tests (`vitest` + `canvas` npm package) for the main draw paths; document the `render_state_ref` contract in a comment block.
+
+---
+
+## 10. Unify timestamps on UTC
+
+**Category: correctness · Effort: M (touches data, needs a migration note).**
+
+Spot timestamps mix timezone bases: `add_spot_to_postgres` builds `HolySpot.time` with local-time `datetime.fromtimestamp(...)` while `timestamp` is a UTC epoch (`collectors/main.py:118`), and the containers pin `TZ=Asia/Jerusalem` (`docker-compose.yml`). Meanwhile the API's time-window queries (`/history`, `/propagation/history`) and the UI's 1-hour trim all reason in epoch/UTC.
+
+Consequences: the string `time` column disagrees with `timestamp` by the server's UTC offset; DST transitions shift it twice a year; anyone comparing `time` against a UTC source (or running the stack with a different host TZ) gets subtly wrong windows — and the dedup key includes `time`, so the same spot arriving via a UTC-based source and a local-time path wouldn't collide.
+
+**Do:** write UTC everywhere (`datetime.fromtimestamp(ts, tz=timezone.utc)`), treat epoch `timestamp` as the single source of truth and derive display strings client-side; keep `TZ` pinning only for log readability. Existing rows keep their meaning if you document the cutover date; a backfill is optional.
+
+---
+
+## Suggested sequencing
+
+```mermaid
+gantt
+    dateFormat X
+    axisFormat %s
+    section Week 1 — stop the bleeding
+        1 Retention fix           :a1, 0, 2
+        2 Tests in CI             :a2, 0, 2
+        4 Valkey persistence      :a3, 2, 3
+        8 API limits + debug logs :a4, 2, 3
+    section Week 2–3 — safety net
+        3 Security hardening      :b1, 3, 5
+        5 Backups + PGDATA move   :b2, 5, 8
+        7 Repo/docs hygiene       :b3, 3, 5
+    section Month 2 — structural
+        6 Retire legacy WS        :c1, 8, 12
+        10 UTC timestamps         :c2, 8, 11
+        9 Frontend refactor       :c3, 11, 16
+```
+
+Items 1, 2, 4, and 8 are each a few hours of work and remove the most acute risks; do them first. Items 3, 5, 7 build the safety net. Items 6, 9, 10 are structural and benefit from the test gate (#2) landing before them.

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,651 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>HolyCluster — Architecture Guide</title>
+<style>
+    :root {
+        --bg: #ffffff; --fg: #1f2430; --muted: #5b6472; --accent: #1a6feb;
+        --card: #f6f8fa; --border: #d9dee5; --warn-bg: #fff7e0; --warn-border: #e0b100;
+        --code-bg: #eef1f5;
+    }
+    @media (prefers-color-scheme: dark) {
+        :root {
+            --bg: #14171d; --fg: #e6e9ef; --muted: #9aa4b2; --accent: #6aa5ff;
+            --card: #1c2129; --border: #313847; --warn-bg: #33290e; --warn-border: #b89311;
+            --code-bg: #232936;
+        }
+    }
+    * { box-sizing: border-box; }
+    body {
+        margin: 0; background: var(--bg); color: var(--fg);
+        font: 16px/1.65 -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    }
+    .layout { display: flex; max-width: 1400px; margin: 0 auto; }
+    nav {
+        width: 270px; flex: none; position: sticky; top: 0; align-self: flex-start;
+        max-height: 100vh; overflow-y: auto; padding: 24px 16px; border-right: 1px solid var(--border);
+        font-size: 13.5px;
+    }
+    nav a { display: block; color: var(--muted); text-decoration: none; padding: 3px 8px; border-radius: 6px; }
+    nav a:hover { color: var(--accent); background: var(--card); }
+    nav .l2 { padding-left: 22px; }
+    nav b { display: block; margin: 10px 0 4px; font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--fg); }
+    main { flex: 1; min-width: 0; padding: 32px 48px 96px; }
+    h1 { font-size: 2.1em; margin: 0 0 4px; }
+    h2 { font-size: 1.5em; margin-top: 2.2em; padding-bottom: 6px; border-bottom: 2px solid var(--border); }
+    h3 { font-size: 1.15em; margin-top: 1.8em; }
+    .subtitle { color: var(--muted); font-size: 1.05em; margin-bottom: 24px; }
+    a { color: var(--accent); }
+    code { background: var(--code-bg); padding: 1px 6px; border-radius: 5px; font-size: .875em; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    pre.plain { background: var(--code-bg); padding: 14px 18px; border-radius: 10px; overflow-x: auto; font-size: 13px; line-height: 1.5; }
+    pre.plain code { background: none; padding: 0; }
+    table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 14.5px; display: block; overflow-x: auto; }
+    th, td { border: 1px solid var(--border); padding: 7px 12px; text-align: left; vertical-align: top; }
+    th { background: var(--card); }
+    .diagram {
+        background: var(--card); border: 1px solid var(--border); border-radius: 12px;
+        padding: 18px; margin: 20px 0; overflow-x: auto;
+    }
+    .diagram .caption { font-size: 12.5px; color: var(--muted); margin-top: 8px; text-align: center; }
+    pre.mermaid { margin: 0; display: flex; justify-content: center; }
+    .warn {
+        background: var(--warn-bg); border-left: 4px solid var(--warn-border);
+        padding: 10px 16px; border-radius: 0 8px 8px 0; margin: 14px 0;
+    }
+    .pill { display: inline-block; background: var(--card); border: 1px solid var(--border); border-radius: 999px; padding: 1px 10px; font-size: 12px; color: var(--muted); margin-right: 6px; }
+    @media (max-width: 900px) { nav { display: none; } main { padding: 24px 20px 80px; } }
+</style>
+</head>
+<body>
+<div class="layout">
+<nav>
+    <b>HolyCluster Architecture</b>
+    <a href="#what">1 · What HolyCluster Is</a>
+    <a href="#context">2 · System Context</a>
+    <a href="#layout">3 · Repository Layout</a>
+    <a href="#backend">4 · Backend</a>
+    <a class="l2" href="#pipeline">Collection pipeline</a>
+    <a class="l2" href="#enrichment">Enrichment</a>
+    <a class="l2" href="#db">Database schema</a>
+    <a class="l2" href="#api">API service</a>
+    <a class="l2" href="#wsproto">WebSocket protocol</a>
+    <a class="l2" href="#jobs">Background jobs</a>
+    <a href="#frontend">5 · Frontend</a>
+    <a class="l2" href="#providers">Provider tree</a>
+    <a class="l2" href="#dataflow">Data flow</a>
+    <a class="l2" href="#canvasmap">Canvas map engine</a>
+    <a class="l2" href="#persistence">Persistence</a>
+    <a href="#catserver">6 · CAT Server</a>
+    <a class="l2" href="#proxytrick">Reverse-proxy trick</a>
+    <a class="l2" href="#radioflow">Radio message flow</a>
+    <a class="l2" href="#packaging">Packaging</a>
+    <a href="#infra">7 · Infrastructure</a>
+    <a class="l2" href="#compose">Compose stack</a>
+    <a class="l2" href="#nginxtls">Nginx &amp; TLS</a>
+    <a class="l2" href="#cicd">CI/CD</a>
+    <a class="l2" href="#topology">Production topology</a>
+    <a href="#devflow">8 · Development Workflow</a>
+    <a href="#gotchas">9 · Maintainer Gotchas</a>
+    <b>Related</b>
+    <a href="improvements.html">Improvement Backlog →</a>
+</nav>
+<main>
+
+<h1>HolyCluster — Architecture Guide</h1>
+<p class="subtitle">A maintainer-oriented explanation of how HolyCluster works, end to end.
+Markdown source: <code>docs/ARCHITECTURE.md</code> · Improvements: <a href="improvements.html">improvements.html</a></p>
+
+<h2 id="what">1 · What HolyCluster Is</h2>
+<p>HolyCluster (<a href="https://holycluster.iarc.org">holycluster.iarc.org</a>) is a <strong>real-time visualization of the amateur-radio DX cluster network</strong>. Ham operators worldwide report stations they hear ("spots": <em>who</em> heard <em>whom</em>, on <em>what frequency</em>, in <em>what mode</em>, <em>when</em>). HolyCluster aggregates spots from many sources, enriches them with geographic data, and draws them live on an interactive world map — and with the optional desktop <strong>CAT server</strong>, clicking a spot tunes the operator's physical radio.</p>
+<table>
+<tr><th>Deliverable</th><th>Source</th><th>What it is</th></tr>
+<tr><td><strong>Web application</strong></td><td><code>ui/</code> + <code>backend/</code></td><td>React SPA served by FastAPI; live spots over WebSocket</td></tr>
+<tr><td><strong>Data platform</strong></td><td><code>backend/</code></td><td>Collectors ingesting telnet DX clusters + POTA/SOTA/WWFF into PostgreSQL/Valkey</td></tr>
+<tr><td><strong>Holy Cluster desktop app</strong></td><td><code>catserver/</code></td><td>Rust Windows app (MSI) bridging the web UI to the radio via OmniRig</td></tr>
+</table>
+
+<h2 id="context">2 · System Context — the 10,000 ft View</h2>
+<div class="diagram"><pre class="mermaid">
+flowchart TB
+    subgraph EXT["External data sources"]
+        TELNET["Telnet DX clusters&lt;br/&gt;DXUSA, VE7CC, K7AR, AI9T, NC7J, WA9PIE-2"]
+        POTA["POTA API"]
+        SOTA["SOTA API"]
+        WWFF["WWFF spots"]
+        QRZ["QRZ.com XML API&lt;br/&gt;callsign → locator"]
+        CTY["CTY files&lt;br/&gt;prefix → DXCC"]
+        NOAA["NOAA SWPC&lt;br/&gt;solar indices"]
+        NG3K["NG3K ADXO&lt;br/&gt;DXpeditions"]
+    end
+    subgraph SERVER["Server (docker compose, backend/)"]
+        COLLECTOR["collector&lt;br/&gt;(Python, asyncio)"]
+        VALKEY[("Valkey&lt;br/&gt;cache + streams")]
+        PG[("PostgreSQL 16&lt;br/&gt;holy_spots2")]
+        API["api&lt;br/&gt;(FastAPI + uvicorn)"]
+        NGINX["nginx&lt;br/&gt;TLS termination"]
+        MONITOR["monitor&lt;br/&gt;Telegram alerts"]
+    end
+    subgraph CLIENT["Operator's computer"]
+        BROWSER["Browser (React SPA)"]
+        CATSRV["Holy Cluster desktop app&lt;br/&gt;(catserver, Rust, :3000)"]
+        RADIO["Transceiver&lt;br/&gt;OmniRig / rigctld"]
+        LOGGER["Logging software&lt;br/&gt;WSJT-X UDP"]
+    end
+    TELNET --> COLLECTOR
+    POTA --> COLLECTOR
+    SOTA --> COLLECTOR
+    WWFF --> COLLECTOR
+    QRZ --> COLLECTOR
+    CTY --> COLLECTOR
+    NG3K --> COLLECTOR
+    NOAA --> API
+    COLLECTOR --> VALKEY
+    COLLECTOR --> PG
+    VALKEY --> API
+    PG --> API
+    API --> NGINX
+    MONITOR -.watches.-> API
+    NGINX <-->|"HTTPS + WSS"| BROWSER
+    NGINX <-->|"HTTPS + WSS"| CATSRV
+    CATSRV <-->|"localhost :3000&lt;br/&gt;proxied UI + /ws"| BROWSER
+    CATSRV <-->|"COM / TCP"| RADIO
+    CATSRV -->|"UDP status packet"| LOGGER
+</pre><div class="caption">Everything in one picture: sources → collector → storage → API → clients, with the desktop app bridging browser and radio.</div></div>
+<p>Two usage modes:</p>
+<ol>
+<li><strong>Plain web usage</strong> — browser talks to <code>https://holycluster.iarc.org</code> directly; radio control is unavailable.</li>
+<li><strong>With the desktop app</strong> — catserver serves the site at <code>http://127.0.0.1:3000</code>, reverse-proxying everything but intercepting radio messages locally (<a href="#proxytrick">§6.1</a>).</li>
+</ol>
+
+<h2 id="layout">3 · Repository Layout</h2>
+<pre class="plain"><code>HolyCluster/
+├── backend/            # Python uv workspace + docker compose stack (the server)
+│   ├── api/            #   FastAPI web/WebSocket server
+│   ├── collectors/     #   Spot ingestion pipeline
+│   ├── monitor/        #   Health checks + Telegram alerts
+│   ├── shared/         #   DB models, geo/QRZ/CTY, settings (Python package)
+│   ├── migrations/     #   Alembic migrations
+│   ├── docker/         #   Dockerfiles (api/collector/monitor/migrate)
+│   ├── infra/          #   nginx, postgres, valkey, certbot configs (AUTHORITATIVE)
+│   ├── docker-compose.yml · deploy.sh · setup.sh
+├── ui/                 # React 18 + Vite SPA (components/CanvasMap = map engine)
+├── catserver/          # Rust desktop CAT-control app (Windows MSI)
+├── shared/             # band_plans.json — single source of band data (backend AND ui)
+├── docs/               # User manual, runbooks, this document
+├── .github/workflows/  # backend.yml, ui.yml, catserver.yml
+├── nginx/ certbot/ postgres/ nginx-ui/   # ⚠ UNTRACKED local scratch (see gotchas)
+└── README.md           # ⚠ Partially stale (references removed ClientSideServer.py)</code></pre>
+<div class="warn"><strong><code>shared/band_plans.json</code></strong> is the cross-stack source of truth for band edges/modes. The backend collector gets it via a docker build context; the UI imports it at build time with a relative path. Moving it breaks both consumers.</div>
+
+<h2 id="backend">4 · The Backend (<code>backend/</code>)</h2>
+<h3>4.1 Workspace packages</h3>
+<p>A <strong>uv workspace</strong> (Python ≥ 3.13) with four members. Everything runs from <code>docker compose up</code>. Lint is Ruff; tests exist but are <strong>not run in CI</strong>.</p>
+<table>
+<tr><th>Package</th><th>Entry point</th><th>Role</th></tr>
+<tr><td><code>api</code></td><td><code>uvicorn api.main:app</code> (:8000)</td><td>HTTP + WebSocket server; also serves the SPA and the MSI</td></tr>
+<tr><td><code>collectors</code></td><td><code>collector</code></td><td>Ingest, enrich, dedupe, persist spots</td></tr>
+<tr><td><code>monitor</code></td><td><code>monitor</code></td><td>Synthetic checks + Telegram alerts</td></tr>
+<tr><td><code>shared</code></td><td><code>ensure_db</code></td><td>SQLModel models, geo/QRZ/CTY logic, pydantic settings</td></tr>
+</table>
+
+<h3 id="pipeline">4.2 The spot collection pipeline</h3>
+<div class="diagram"><pre class="mermaid">
+flowchart LR
+    subgraph SOURCES["Source tasks (asyncio)"]
+        T1["Telnet clients&lt;br/&gt;one per cluster server"]
+        P1["POTA poller · 60s"]
+        S1["SOTA poller · 60s"]
+        W1["WWFF poller · 30s"]
+    end
+    Q{{"asyncio.Queue&lt;br/&gt;maxsize 1000"}}
+    subgraph CONSUMER["process_spots (single consumer)"]
+        DEDUP["Dedup: Valkey SET NX&lt;br/&gt;key = time:dx:freq:spotter · TTL 60s"]
+        ENRICH["enrich_spot&lt;br/&gt;band/mode + geo + dxpedition"]
+        VALIDATE["validate&lt;br/&gt;callsign, band, locator"]
+    end
+    PG[("PostgreSQL&lt;br/&gt;holy_spots2")]
+    STREAM[("Valkey stream-api&lt;br/&gt;maxlen 10000")]
+    T1 --> Q
+    P1 --> Q
+    S1 --> Q
+    W1 --> Q
+    Q --> DEDUP --> ENRICH --> VALIDATE
+    VALIDATE -->|"always"| PG
+    VALIDATE -->|"if locator+band+mode present"| STREAM
+    STREAM -->|"consumer group api-group"| APIB["api: spots_broadcast_task"]
+    APIB -->|"WebSocket broadcast"| CLIENTS["All connected browsers"]
+</pre><div class="caption">All sources feed one queue; one consumer enriches and persists. Sources also record arrivals to the <code>stream-arrivals</code> analytics stream.</div></div>
+<ul>
+<li><strong>Telnet clusters</strong> (<code>collectors/telnet/</code>): server list in <code>telnet_servers.csv</code>; one task per server, exponential reconnect backoff (60&nbsp;s → 24&nbsp;h), regex parsing, keepalive ping on 60&nbsp;s silence. Spotters <code>W3LPL</code> and <code>J9AQ</code> are hardcoded-banned.</li>
+<li><strong>POTA/SOTA/WWFF</strong>: JSON pollers sharing <code>run_json_spot_collector</code> (dedup, arrival recording, error backoff ≤ 300&nbsp;s).</li>
+<li>There is <strong>no RBN or DXHeat collector</strong> — telnet clusters are the live feed.</li>
+</ul>
+
+<h3 id="enrichment">4.3 Spot enrichment</h3>
+<div class="diagram"><pre class="mermaid">
+sequenceDiagram
+    participant C as process_spots
+    participant BP as band_plans.json
+    participant V as Valkey (geo cache)
+    participant Q as QRZ.com XML API
+    participant CTY as CTY file (in-process)
+    participant PG as PostgreSQL
+    C->>BP: band + mode from frequency (mode also from comment keywords)
+    Note over C: missing band → spot dropped
+    C->>V: GET geo:{callsign}
+    alt cache hit
+        V-->>C: locator, lat/lon, dxcc, zones
+    else cache miss
+        C->>Q: XML lookup (session key)
+        Q-->>C: grid locator, state, zones
+        C->>CTY: prefix → DXCC, continent (always — coords fallback if QRZ has no grid)
+        C->>V: SET geo:{callsign} · TTL 3600s
+    end
+    C->>C: is_active_dxpedition? (NG3K daily cache, prefix match)
+    C->>PG: INSERT INTO holy_spots2
+</pre><div class="caption">Both spotter and DX callsigns are geolocated — the map needs both arc endpoints.</div></div>
+<div class="warn">The hardcoded override table for ~25 special callsigns lives in <code>backend/shared/src/shared/geo.py:33-60</code> — this is where you add fixes per the <code>fix_missing_spot.md</code> runbook. The QRZ session key is refreshed hourly by the <em>collector</em>; the API's <code>/locator</code> returns 503 without it.</div>
+
+<h3 id="db">4.4 Database schema</h3>
+<p>PostgreSQL 16 via <strong>SQLModel</strong> + asyncpg; async Alembic migrations run by the one-shot <code>migrate</code> compose service. Table names carry a historical <code>2</code> suffix.</p>
+<div class="diagram"><pre class="mermaid">
+erDiagram
+    HOLY_SPOTS2 {
+        int id PK
+        string time "UK(time,spotter,dx)"
+        int timestamp "epoch, indexed"
+        string spotter_callsign
+        string spotter_locator
+        float spotter_lat_lon
+        int spotter_dxcc_code
+        string spotter_continent
+        int spotter_cq_itu_zones
+        string dx_callsign
+        string dx_locator
+        float dx_lat_lon
+        int dx_dxcc_code
+        string dx_continent
+        int dx_cq_itu_zones
+        float frequency
+        string band
+        string mode
+        string comment
+        bool is_dxpedition
+        string pota_reference
+        int sota_points
+    }
+    GEO_CACHE {
+        string callsign PK
+        string locator
+        float lat_lon
+        int dxcc_code
+        string continent
+        datetime date_time
+    }
+    PROPAGATION_MEASUREMENTS {
+        int id PK
+        string metric "UK(metric,timestamp)"
+        int timestamp "indexed"
+        float value
+        datetime collected_at
+    }
+    SPOTS_WITH_ISSUES2 {
+        int id PK
+        string issues "write-dead: nothing inserts"
+    }
+</pre><div class="caption">Four tables. Lat/lon and zone pairs are shown collapsed here for readability — see <code>backend/shared/src/shared/db.py</code> for exact columns.</div></div>
+<div class="warn"><strong>Two known data-lifecycle defects</strong> (Improvement #1): the retention job filters <code>HolySpot.date_time</code>, a column that doesn't exist (cleanup of <code>holy_spots2</code> is broken), and nothing writes to <code>spots_with_issues2</code> although the runbook and an endpoint assume it's populated.</div>
+
+<h3 id="api">4.5 The API service</h3>
+<p>FastAPI app (<code>api/src/api/main.py</code>, ~1100 lines), GZip, docs disabled. It <strong>also serves the React SPA</strong> (static <code>/assets</code> + <code>index.html</code> catch-all) and the catserver MSI — nginx in front is a pure TLS proxy.</p>
+<table>
+<tr><th>Method</th><th>Path</th><th>Purpose</th></tr>
+<tr><td>GET</td><td><code>/locator/{callsign}</code></td><td>Callsign → locator/lat/lon (503 without QRZ session)</td></tr>
+<tr><td>GET</td><td><code>/geocache/all</code>, <code>/geocache/{callsign}</code></td><td>Geo cache dump / single record (⚠ <code>/all</code> unbounded)</td></tr>
+<tr><td>GET</td><td><code>/spots_with_issues</code></td><td>Dump of <code>spots_with_issues2</code> (currently always empty)</td></tr>
+<tr><td>GET</td><td><code>/propagation</code> · <code>/propagation/history</code></td><td>Latest solar indices / time-series (max 24 h window)</td></tr>
+<tr><td>GET</td><td><code>/voacap?...</code></td><td>VOACAP HF propagation grid (CPU-heavy, threaded)</td></tr>
+<tr><td>GET</td><td><code>/dxpeditions</code></td><td>Active DXpeditions (from Valkey)</td></tr>
+<tr><td>GET</td><td><code>/history?start_time&amp;end_time</code></td><td>Historical spots (max 24 h window)</td></tr>
+<tr><td>GET</td><td><code>/cluster_stats?hours</code></td><td>Source-overlap analytics from <code>stream-arrivals</code></td></tr>
+<tr><td>GET</td><td><code>/catserver/latest</code> · <code>/catserver/download</code></td><td>Desktop app version + MSI download</td></tr>
+<tr><td>GET</td><td><code>/health</code> · <code>/</code> · <code>/{path}</code></td><td>Liveness · SPA catch-all</td></tr>
+<tr><td>WS</td><td><code>/ws</code></td><td><strong>Primary versioned protocol</strong> (below)</td></tr>
+<tr><td>WS</td><td><code>/spots_ws</code>, <code>/submit_spot</code>, <code>/radio</code></td><td>⚠ Legacy endpoints, still live</td></tr>
+</table>
+
+<h3 id="wsproto">4.6 WebSocket protocol</h3>
+<p>One multiplexed socket, protocol version 1: every message is JSON with <code>{"version": 1, "type": ...}</code>.</p>
+<div class="diagram"><pre class="mermaid">
+sequenceDiagram
+    participant B as Browser (useWs.jsx)
+    participant A as api /ws
+    participant S as Valkey stream-api
+    B->>A: {version:1, type:"spots", action:"initial"}
+    A-->>B: {type:"spots", spots:[...up to 500...]}
+    loop live broadcast
+        S->>A: XREADGROUP api-group
+        A-->>B: {type:"spots", event:"update", spots:[...]}
+    end
+    Note over B,A: on reconnect → {action:"catch_up", last_time}
+    B->>A: {version:1, type:"submit", spotter, dx, freq, comment}
+    A-->>B: {type:"submit", status:"success"|"failure"}
+    B->>A: {version:1, type:"hunter", action:"start/add/finish", callsigns}
+    A-->>B: batch callsign resolutions (4 workers × 50)
+    B->>A: {version:1, type:"radio", ...}
+    A-->>B: {type:"radio", status:"unavailable"}
+    Note over B,A: radio messages only work when the socket passes through catserver
+</pre><div class="caption">The <code>radio</code> type is a deliberate no-op on the backend — the catserver intercepts it locally when installed.</div></div>
+
+<h3 id="jobs">4.7 Background jobs</h3>
+<table>
+<tr><th>Where</th><th>Job</th><th>Interval</th></tr>
+<tr><td>collector</td><td>QRZ session key refresh</td><td>1 h</td></tr>
+<tr><td>collector</td><td>NG3K DXpedition refresh</td><td>24 h (retry 10 min)</td></tr>
+<tr><td>collector</td><td><code>trim_arrivals_stream</code> (7-day retention)</td><td>1 h</td></tr>
+<tr><td>collector</td><td>POTA / SOTA / WWFF pollers</td><td>60 / 60 / 30 s</td></tr>
+<tr><td>api</td><td>NOAA propagation fetch + persist</td><td>1 h (retry 10 s)</td></tr>
+<tr><td>api</td><td><code>spots_broadcast_task</code> (stream consumer)</td><td>continuous</td></tr>
+<tr><td>monitor</td><td>metric / heartbeat / WS / container checks</td><td>60 s</td></tr>
+<tr><td>external</td><td><code>cleanup_postgres</code> retention job</td><td>⚠ external cron, currently buggy</td></tr>
+</table>
+<p><span class="pill">config</span> Settings are pydantic-settings classes reading <code>backend/.env</code>; a <code>/.dockerenv</code> check auto-selects docker vs localhost hosts. Key vars: <code>POSTGRES_*</code>, <code>VALKEY_*</code>, <code>QRZ_*</code>, <code>USERNAME_FOR_TELNET_CLUSTERS</code>, <code>UI_DIST_PATH</code>, <code>CATSERVER_MSI_DIR</code>, <code>DOMAIN</code>, <code>TELEGRAM_*</code>.</p>
+
+<h2 id="frontend">5 · The Frontend (<code>ui/</code>)</h2>
+<p>React 18 (JSX, no TypeScript) + Vite 6 + Tailwind. Formatter/linter: <strong>Biome</strong>. Tests: <strong>Vitest</strong>. The map is <strong>HTML5 Canvas + d3-geo</strong> (not Leaflet). In dev, Vite proxies all API/WS routes to <code>holycluster-dev.iarc.org</code> — <code>npm run dev</code> needs no local backend.</p>
+
+<h3 id="providers">5.1 State management — the provider tree</h3>
+<p>All global state is React Context. <strong><code>ProfilesProvider</code> is the backbone</strong>: nearly every persistent setting is a section of the "active profile" in localStorage.</p>
+<div class="diagram"><pre class="mermaid">
+flowchart TB
+    BR["BrowserRouter (main.jsx)"] --> WS["WsProvider&lt;br/&gt;single /ws socket · pub/sub by message type"]
+    WS --> PROF["ProfilesProvider&lt;br/&gt;localStorage 'profiles' — multi-profile store"]
+    PROF --> COL["ColorsProvider&lt;br/&gt;themes + map themes"]
+    COL --> FIL["FiltersProvider&lt;br/&gt;band/mode/continent + callsign rules + shared-URL override"]
+    FIL --> SET["SettingsProvider&lt;br/&gt;= active profile's settings section"]
+    SET --> RAD["RadioProvider&lt;br/&gt;CAT status/freq/mode"]
+    RAD --> SPI["SpotInteractionProvider&lt;br/&gt;hovered/pinned spot, search"]
+    SPI --> MC["MainContainer"]
+    MC --> REST["RestDataProvider&lt;br/&gt;propagation + dxpeditions polls"]
+    REST --> SPOT["SpotDataProvider&lt;br/&gt;live WS | history → filtering"]
+    SPOT --> UI2["TopBar / LeftColumn / CanvasMap / SpotsTable / SidePanel / HistoryBar"]
+</pre><div class="caption">⚠ Ordering is load-bearing: Settings/Filters/Colors all read from ProfilesProvider and throw outside it.</div></div>
+<p>Profile sections (<code>utils/profile_data.js</code>): <code>settings</code>, <code>filters</code>, <code>callsign_filters</code>, <code>hunter</code>, <code>map_controls</code>, <code>map_view</code>, <code>table_sort</code>, <code>history</code>, <code>panels</code>, <code>radio</code>.</p>
+
+<h3 id="dataflow">5.2 Data flow into the UI</h3>
+<div class="diagram"><pre class="mermaid">
+flowchart LR
+    subgraph TRANSPORT["Transport"]
+        WSOCK["WebSocket /ws"]
+        REST["REST fetch"]
+    end
+    subgraph DATA["Data hooks"]
+        SWS["useSpotWebSocket&lt;br/&gt;normalize · 1h trim · catch_up"]
+        HIST["useHistorySpots&lt;br/&gt;IndexedDB gap-fill cache"]
+        FILT["useSpotFiltering&lt;br/&gt;all filters → slice(0,100)"]
+        RESTD["useRestData&lt;br/&gt;hourly polls"]
+        VOA["useVoacap&lt;br/&gt;debounce + LRU"]
+        RADH["useRadio"]
+    end
+    subgraph VIEW["Views"]
+        MAP["CanvasMap"]
+        TABLE["SpotsTable"]
+        BARS["Propagation / Frequency bars"]
+        HP["HunterPanel / DXpeditions"]
+    end
+    WSOCK -->|"type: spots"| SWS
+    WSOCK -->|"type: radio"| RADH
+    REST -->|"/history"| HIST
+    REST -->|"/propagation /dxpeditions"| RESTD
+    REST -->|"/voacap"| VOA
+    SWS --> FILT
+    HIST --> FILT
+    FILT --> MAP
+    FILT --> TABLE
+    RESTD --> BARS
+    RESTD --> HP
+    VOA --> MAP
+    RADH --> BARS
+</pre><div class="caption">Silent limits: live spots trimmed to the last hour; filtered list capped at 100; alerted spots bypass most filters; WS sends dropped when the socket isn't open.</div></div>
+
+<h3 id="canvasmap">5.3 The canvas map engine</h3>
+<div class="diagram"><pre class="mermaid">
+flowchart TB
+    subgraph CANVASES["Stacked canvas layers (CanvasMap/index.jsx)"]
+        L1["1 · map_canvas — countries, borders, graticule, zones,&lt;br/&gt;Maidenhead grid, day/night terminator&lt;br/&gt;(draw_map.js — 1546 lines)"]
+        L2["2 · voacap_canvas — propagation heat overlay"]
+        L3["3 · spots_canvas — great-circle arcs, mode-shaped markers,&lt;br/&gt;azimuth line — redrawn per animation frame"]
+        L4["4 · shadow_canvas (offscreen) — pixel hit-testing"]
+    end
+    PROJ["useMapProjection&lt;br/&gt;d3.geoAzimuthalEquidistant | geoOrthographic (globe)"]
+    GEST["useMapGestures (602 lines)&lt;br/&gt;pan/zoom/tap/context-menu"]
+    REDRAW["useMapRedraw&lt;br/&gt;3 effects + rAF loop + minute tick (terminator)"]
+    RSR["render_state_ref (mutable ref)&lt;br/&gt;latest props for the rAF loop"]
+    PROJ --> L1
+    PROJ --> L3
+    GEST --> PROJ
+    REDRAW --> CANVASES
+    RSR --> REDRAW
+</pre><div class="caption">The terminator draws a 90°-radius geoCircle at the solar antipode (solar-calculator). The mutable <code>render_state_ref</code> deliberately bypasses React — stale-closure territory when editing <code>useMapRedraw.js</code>.</div></div>
+
+<h3 id="persistence">5.4 Persistence</h3>
+<ul>
+<li><strong><code>"profiles"</code></strong> (localStorage) — the entire multi-profile store; every write re-serializes and sanitizes it; legacy keys migrated on first load.</li>
+<li><strong>IndexedDB</strong> — history-spot interval cache with gap-fill and idle-time eviction every 3 h.</li>
+<li><strong>URL param</strong> — shareable filter links temporarily override profile filters.</li>
+<li>No server-side accounts or sync — profiles export/import as JSON files in Settings.</li>
+</ul>
+<table>
+<tr><th>Feature</th><th>Key files</th><th>Notes</th></tr>
+<tr><td>Spots table</td><td><code>SpotsTable.jsx</code> (908 ln)</td><td>Row click tunes radio; context menu adds filters</td></tr>
+<tr><td>Filters</td><td><code>useFilters.jsx</code>, <code>FilterModal.jsx</code></td><td>Shareable URLs; 3-state zone cycle</td></tr>
+<tr><td>Hunter panel</td><td><code>HunterPanel.jsx</code> (729 ln)</td><td>ADIF import in a Web Worker (50 MB limit)</td></tr>
+<tr><td>VOACAP overlay · History playback</td><td><code>useVoacap.jsx</code> · <code>history/</code></td><td>⚠ both dev-mode gated</td></tr>
+<tr><td>Guided tour</td><td><code>tour/</code> (react-joyride)</td><td>Targets <code>data-tour</code> attributes</td></tr>
+<tr><td>Radio CAT</td><td><code>useRadio.jsx</code></td><td>Features gated by parsed catserver version</td></tr>
+</table>
+
+<h2 id="catserver">6 · The CAT Server (<code>catserver/</code>)</h2>
+<p>A Rust desktop app (product name <strong>"Holy Cluster"</strong>, <code>HolyCluster.exe</code>) bridging the <em>remote</em> web UI to the <em>local</em> radio.</p>
+
+<h3 id="proxytrick">6.1 The reverse-proxy trick</h3>
+<div class="diagram"><pre class="mermaid">
+flowchart LR
+    subgraph LOCAL["Operator's PC"]
+        B["Browser at&lt;br/&gt;http://127.0.0.1:3000"]
+        CS["catserver&lt;br/&gt;(axum server :3000)"]
+        R["Radio&lt;br/&gt;OmniRig (COM) or rigctld :4532"]
+        LOG["Logger (WSJT-X UDP)"]
+    end
+    REMOTE["holycluster.iarc.org&lt;br/&gt;(--dev-server → dev site)"]
+    B -->|"all HTTP requests"| CS
+    CS -->|"reverse-proxies pages, assets, API"| REMOTE
+    B <-->|"/ws (one socket)"| CS
+    CS <-->|"non-radio messages forwarded"| REMOTE
+    CS <-->|"type: radio handled locally"| R
+    CS -->|"HighlightSpot → UDP packet"| LOG
+</pre><div class="caption">The same web UI gains radio control with no special "local mode": messages with <code>version==1 &amp;&amp; type=="radio"</code> are handled locally; everything else is forwarded upstream.</div></div>
+<p>A single-instance guard makes a second launch POST <code>/open</code> to the running instance. <code>--local-ui</code> serves a local <code>ui/dist</code> instead of proxying; <code>--dummy</code> uses a fake radio.</p>
+
+<h3 id="modules">6.2 Modules and rig backends</h3>
+<table>
+<tr><th>Module</th><th>Role</th></tr>
+<tr><td><code>main.rs</code></td><td>Args, single-instance guard, backend selection, tray icon</td></tr>
+<tr><td><code>server.rs</code></td><td>axum HTTP/WS server on <code>0.0.0.0:3000</code>, proxy, radio loop</td></tr>
+<tr><td><code>rig.rs</code></td><td><code>Radio</code> trait + thread-safe <code>AnyRadio</code> (lock-poison recovery)</td></tr>
+<tr><td><code>omnirig.rs</code></td><td><strong>Windows</strong>: OmniRig via COM/IDispatch (winsafe)</td></tr>
+<tr><td><code>rigctld.rs</code></td><td><strong>non-Windows</strong>: TCP to hamlib <code>rigctld</code> :4532</td></tr>
+<tr><td><code>dummy.rs</code> · <code>freq.rs</code> · <code>tray_icon.rs</code></td><td>Fake radio · Freq newtype (Hz as u32) · system tray</td></tr>
+<tr><td><code>reporting.rs</code></td><td>WSJT-X-compatible UDP status packet for logger integration</td></tr>
+</table>
+<p>Backend selection is compile-time by OS; both real backends auto-reinit after 5 consecutive failures. Missing OmniRig → opens the site's <code>/omnirig-error</code> page and exits.</p>
+
+<h3 id="radioflow">6.3 Radio control message flow</h3>
+<div class="diagram"><pre class="mermaid">
+sequenceDiagram
+    participant UI as Web UI (useRadio.jsx)
+    participant CS as catserver /ws
+    participant RIG as OmniRig / rigctld
+    participant LOG as Logger (UDP)
+    Note over UI,CS: user clicks a spot row
+    UI->>CS: {type:"radio", action:"SetModeAndFreq", mode:"CW", freq:14025.0}
+    CS->>CS: derive USB/LSB from band
+    CS->>RIG: set frequency + mode (Slot A)
+    UI->>CS: {action:"SetRig", rig:2}
+    CS->>RIG: switch to Rig 2
+    UI->>CS: {action:"HighlightSpot", dx_callsign, freq, mode, udp_port}
+    CS->>LOG: WSJT-X status UDP → 127.0.0.1:udp_port
+    loop every 500ms (only on change)
+        CS->>RIG: poll status/freq/mode
+        CS-->>UI: {type:"radio", event:"status", freq, mode, current_rig, catserver_version}
+    end
+</pre><div class="caption">The <code>catserver_version</code> field powers the UI's "new version available" nudge (compared against <code>/catserver/latest</code>).</div></div>
+
+<h3 id="packaging">6.4 Packaging and distribution</h3>
+<div class="diagram"><pre class="mermaid">
+flowchart LR
+    DEV["push to dev /&lt;br/&gt;tag catserver-v*"] --> GH["GitHub Actions&lt;br/&gt;ghcr.io/iarc-il/catserver-ci&lt;br/&gt;(Rust + mingw + Wine + WiX 5)"]
+    GH --> FMT["cargo fmt + clippy -D warnings"]
+    FMT --> BUILD["cargo build --release&lt;br/&gt;x86_64-pc-windows-gnu"]
+    BUILD --> MSI["build_msi.sh → WiX → .msi"]
+    MSI --> PUB["publish.sh: scp → /opt/msi&lt;br/&gt;+ update 'latest' file"]
+    PUB --> SERVE["api serves /catserver/download&lt;br/&gt;UI links to it"]
+</pre><div class="caption">The Windows MSI is cross-built on Linux. <code>build.rs</code> panics without a reachable <code>catserver-v*</code> tag — shallow clones fail to build. Dev builds bake in <code>--dev-server</code>.</div></div>
+
+<h2 id="infra">7 · Infrastructure &amp; Deployment</h2>
+<h3 id="compose">7.1 Docker Compose stack</h3>
+<p>Single compose file: <code>backend/docker-compose.yml</code>; default bridge network; env from <code>backend/.env</code>.</p>
+<div class="diagram"><pre class="mermaid">
+flowchart TB
+    subgraph EDGE["Edge"]
+        NG["nginx :80 :443 :9999&lt;br/&gt;TLS termination · envsubst template"]
+        CB["certbot&lt;br/&gt;renew loop every 6h"]
+    end
+    subgraph APP["Application"]
+        API["api :8000&lt;br/&gt;FastAPI — serves SPA + API + MSI"]
+        COLL["collector"]
+        MON["monitor&lt;br/&gt;docker.sock + Telegram"]
+    end
+    subgraph DATA["Data"]
+        PGS[("postgres 16.9&lt;br/&gt;127.0.0.1:15432&lt;br/&gt;bind mount infra/postgres/data")]
+        VK[("valkey 8.1.4&lt;br/&gt;127.0.0.1:6379&lt;br/&gt;⚠ NO persistence volume")]
+    end
+    MIG["migrate (one-shot)&lt;br/&gt;ensure_db + alembic upgrade head"]
+    NUI["nginx_ui :8080/:8443&lt;br/&gt;(dev profile only)"]
+    NG -->|"proxy / → api:8000"| API
+    CB <-->|"shared certbot volumes"| NG
+    MIG --> PGS
+    API --> VK
+    API --> PGS
+    COLL --> VK
+    COLL --> PGS
+    MON -.->|"docker ps via socket"| APP
+    NUI -.->|"manages nginx config"| NG
+</pre><div class="caption">Mounted into <code>api</code> from the host: the UI dist (rsynced by CI), the MSI dir (scp'd by CI), and logs. <code>monitor</code>/<code>nginx_ui</code> mount the docker socket.</div></div>
+
+<h3 id="nginxtls">7.2 Nginx routing and TLS</h3>
+<p>The <strong>authoritative config is <code>backend/infra/nginx/nginx.conf.template</code></strong>, rendered at container start with <code>envsubst '${DOMAIN}'</code>. The committed <code>nginx.conf</code> next to it is a stale render — editing it does nothing. Blocks: <code>:80</code> ACME + redirect · <code>:443</code> proxy to <code>api:8000</code> with WS upgrade · <code>:9999</code> nginx-ui admin · <code>:3000</code> passthrough to host Grafana.</p>
+<div class="diagram"><pre class="mermaid">
+sequenceDiagram
+    participant CB as certbot container
+    participant FS as shared volume infra/certbot/conf
+    participant NG as nginx container
+    loop every 6h
+        CB->>FS: certbot renew (webroot via :80)
+    end
+    loop every 6h (separate loop in nginx compose command)
+        NG->>FS: stat fullchain.pem mtime
+        alt mtime changed
+            NG->>NG: nginx -s reload
+        end
+    end
+    Note over NG: mtime-polling avoids reload churn that would kill&lt;br/&gt;long-lived WebSockets. ⚠ Reverting the compose command&lt;br/&gt;to the Dockerfile CMD silently breaks cert pickup.
+</pre><div class="caption">First-time issuance is manual via <code>backend/setup.sh</code> (self-signed bootstrap → real certbot → reload).</div></div>
+
+<h3 id="cicd">7.3 CI/CD pipelines</h3>
+<div class="diagram"><pre class="mermaid">
+flowchart TB
+    TRIG["push dev → dev server&lt;br/&gt;tag backend-v* / v* / catserver-v* → prod"]
+    subgraph BE["backend.yml — paths: backend/**"]
+        B1["ruff check + format&lt;br/&gt;⚠ NO tests"] --> B2["SSH: bash deploy.sh ref"]
+        B2 --> B3["deploy.sh: git reset --hard,&lt;br/&gt;diff-map files → services,&lt;br/&gt;rebuild only affected, migrate if needed"]
+    end
+    subgraph FE["ui.yml — paths: ui/**"]
+        U1["npm ci → biome → vite build&lt;br/&gt;⚠ vitest NOT run"] --> U2["rsync ui/dist → DEPLOY_PATH&lt;br/&gt;(bind-mounted into api)"]
+    end
+    subgraph CS["catserver.yml — paths: catserver/**"]
+        C1["fmt + clippy + release build + MSI"] --> C2["scp MSI → /opt/msi + latest"]
+    end
+    TRIG --> BE
+    TRIG --> FE
+    TRIG --> CS
+</pre><div class="caption"><code>deploy.sh</code> maps changed paths to compose services and restarts only what changed (nginx last, monitor stopped first). It hard-resets the server working tree — never hand-edit on the server.</div></div>
+
+<h3 id="topology">7.4 Production topology</h3>
+<div class="diagram"><pre class="mermaid">
+flowchart TB
+    subgraph PROD["Prod server — holycluster.iarc.org"]
+        REPO1["repo checkout at REPO_ROOT_PROD&lt;br/&gt;backend/ compose stack"]
+        HOSTP["host: /opt/msi · UI dist dir · Grafana :3000"]
+    end
+    subgraph DEVS["Dev server — holycluster-dev.iarc.org"]
+        REPO2["repo checkout at REPO_ROOT_DEV&lt;br/&gt;same stack, dev branch"]
+    end
+    GH2["GitHub Actions"] -->|"branch dev"| DEVS
+    GH2 -->|"tags"| PROD
+    USERS["Operators"] --> PROD
+    TESTERS["Team · catserver dev builds · UI dev proxy"] --> DEVS
+</pre><div class="caption">The UI dev proxy and catserver <code>--dev-server</code> both target the dev domain, so development runs against live dev data.</div></div>
+
+<h2 id="devflow">8 · Development Workflow</h2>
+<pre class="plain"><code># Frontend (no local backend needed — proxies to the dev server)
+cd ui &amp;&amp; npm install
+npm run dev        # Vite dev server
+npm run check      # biome + vitest
+
+# Backend (full stack)
+cd backend
+cp .env.example .env    # fill in QRZ creds, telnet username, paths
+docker compose up       # postgres, valkey, migrate, collector, api, monitor, nginx
+uv run pytest           # package tests (pytest not in deps — uvx pytest works too)
+
+# Catserver (any OS, fake radio)
+cd catserver
+cargo run -- --dummy              # local server :3000
+cargo run -- --dummy --local-ui   # serve local ui/dist instead of proxying
+# NOTE: needs a reachable catserver-v* git tag or build.rs panics</code></pre>
+<p><strong>Releases:</strong> merge to <code>dev</code> → auto-deploy to the dev server. Tag <code>backend-vX</code> / <code>vX</code> (UI) / <code>catserver-vX</code> → deploy to prod.</p>
+
+<h2 id="gotchas">9 · Maintainer Gotchas</h2>
+<ol>
+<li><strong>Retention cleanup is broken</strong> — <code>cleanup_postgres_tables.py</code> references nonexistent <code>HolySpot.date_time</code>; <code>holy_spots2</code> grows unbounded.</li>
+<li><strong><code>fix_missing_spot.md</code> is partly obsolete</strong> — nothing writes to <code>spots_with_issues2</code> anymore.</li>
+<li><strong>CI runs zero tests</strong> — backend pytest and UI vitest suites exist but only linters gate deploys.</li>
+<li><strong>Valkey has no persistence</strong> — restart loses geo cache, dedup keys, streams, and the QRZ session key (<code>/locator</code> 503s until refresh).</li>
+<li><strong>Edit <code>nginx.conf.template</code>, not <code>nginx.conf</code></strong> — only the template is rendered at runtime.</li>
+<li><strong>Legacy protocol duplication</strong> — legacy WS endpoints and dual message enums still live alongside the v1 <code>/ws</code> protocol.</li>
+<li><strong>catserver binds <code>0.0.0.0:3000</code></strong> — the radio bridge is reachable from the LAN.</li>
+<li><strong>QRZ password goes into a URL query string</strong> (<code>shared/qrz.py</code>).</li>
+<li><strong>Untracked shadow trees</strong> at repo root (<code>nginx/</code>, <code>certbot/</code>, <code>postgres/</code>, <code>nginx-ui/</code>) — the authoritative infra is <code>backend/infra/</code>; live PGDATA sits inside the repo tree.</li>
+<li><strong>Stale README</strong> — <code>ClientSideServer.py</code> and the pip flow no longer exist.</li>
+<li><strong>Timezone mix</strong> — <code>HolySpot.time</code> is local time (<code>TZ=Asia/Jerusalem</code>) while <code>timestamp</code> is epoch.</li>
+<li><strong>Frontend hot spots</strong> — <code>draw_map.js</code> (1546 ln), <code>SpotsTable.jsx</code> (908), <code>MapControls.jsx</code> (774), <code>useMapGestures.js</code> (602); the rAF loop reads a mutable ref outside React.</li>
+<li><strong>Silent UI limits</strong> — 1-hour trim, 100-spot cap, dropped sends on closed socket, dev-mode-gated features.</li>
+<li><strong>Version-gated radio features</strong> — spot highlight only fires when catserver &gt; 1.1.0.0; version parsing is regex on git-describe.</li>
+</ol>
+
+<p style="margin-top:48px;color:var(--muted);font-size:13px;">Generated from a full-repo architecture review · July 2026 · Diagrams require internet access (Mermaid via CDN); the same diagrams are in <code>docs/ARCHITECTURE.md</code>.</p>
+</main>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script>
+    mermaid.initialize({
+        startOnLoad: true,
+        securityLevel: "loose",
+        theme: window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "default",
+    });
+</script>
+</body>
+</html>

--- a/docs/improvements.html
+++ b/docs/improvements.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>HolyCluster — Improvement Backlog</title>
+<style>
+    :root {
+        --bg: #ffffff; --fg: #1f2430; --muted: #5b6472; --accent: #1a6feb;
+        --card: #f6f8fa; --border: #d9dee5; --warn-bg: #fff7e0; --warn-border: #e0b100;
+        --code-bg: #eef1f5; --crit: #c62828; --high: #e65100; --med: #b8860b; --low: #2e7d32;
+    }
+    @media (prefers-color-scheme: dark) {
+        :root {
+            --bg: #14171d; --fg: #e6e9ef; --muted: #9aa4b2; --accent: #6aa5ff;
+            --card: #1c2129; --border: #313847; --warn-bg: #33290e; --warn-border: #b89311;
+            --code-bg: #232936; --crit: #ef5350; --high: #ff9800; --med: #d4b106; --low: #66bb6a;
+        }
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--bg); color: var(--fg);
+        font: 16px/1.65 -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+    .layout { display: flex; max-width: 1400px; margin: 0 auto; }
+    nav { width: 290px; flex: none; position: sticky; top: 0; align-self: flex-start;
+        max-height: 100vh; overflow-y: auto; padding: 24px 16px; border-right: 1px solid var(--border); font-size: 13.5px; }
+    nav a { display: block; color: var(--muted); text-decoration: none; padding: 3px 8px; border-radius: 6px; }
+    nav a:hover { color: var(--accent); background: var(--card); }
+    nav b { display: block; margin: 10px 0 4px; font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--fg); }
+    main { flex: 1; min-width: 0; padding: 32px 48px 96px; }
+    h1 { font-size: 2.1em; margin: 0 0 4px; }
+    h2 { font-size: 1.45em; margin-top: 2.4em; padding-bottom: 6px; border-bottom: 2px solid var(--border); }
+    .subtitle { color: var(--muted); font-size: 1.05em; margin-bottom: 24px; }
+    a { color: var(--accent); }
+    code { background: var(--code-bg); padding: 1px 6px; border-radius: 5px; font-size: .875em;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 14.5px; display: block; overflow-x: auto; }
+    th, td { border: 1px solid var(--border); padding: 7px 12px; text-align: left; vertical-align: top; }
+    th { background: var(--card); }
+    .diagram { background: var(--card); border: 1px solid var(--border); border-radius: 12px;
+        padding: 18px; margin: 20px 0; overflow-x: auto; }
+    .diagram .caption { font-size: 12.5px; color: var(--muted); margin-top: 8px; text-align: center; }
+    pre.mermaid { margin: 0; display: flex; justify-content: center; }
+    .warn { background: var(--warn-bg); border-left: 4px solid var(--warn-border);
+        padding: 10px 16px; border-radius: 0 8px 8px 0; margin: 14px 0; }
+    .meta { margin: 4px 0 14px; }
+    .tag { display: inline-block; border-radius: 999px; padding: 2px 12px; font-size: 12.5px; font-weight: 600;
+        margin-right: 8px; border: 1px solid var(--border); background: var(--card); }
+    .tag.crit { color: var(--crit); border-color: var(--crit); }
+    .tag.high { color: var(--high); border-color: var(--high); }
+    .tag.med { color: var(--med); border-color: var(--med); }
+    .tag.low { color: var(--low); border-color: var(--low); }
+    .do { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 12px 16px; margin: 14px 0; }
+    .do::before { content: "Do: "; font-weight: 700; }
+    @media (max-width: 900px) { nav { display: none; } main { padding: 24px 20px 80px; } }
+</style>
+</head>
+<body>
+<div class="layout">
+<nav>
+    <b>Improvement Backlog</b>
+    <a href="#overview">Priority Overview</a>
+    <a href="#i1">1 · Fix data retention pipeline</a>
+    <a href="#i2">2 · Run tests in CI</a>
+    <a href="#i3">3 · Security hardening</a>
+    <a href="#i4">4 · Valkey persistence</a>
+    <a href="#i5">5 · PostgreSQL backups</a>
+    <a href="#i6">6 · Retire legacy WebSockets</a>
+    <a href="#i7">7 · Repo &amp; docs hygiene</a>
+    <a href="#i8">8 · Bound API endpoints</a>
+    <a href="#i9">9 · Frontend refactor + tests</a>
+    <a href="#i10">10 · Unify timestamps on UTC</a>
+    <a href="#seq">Suggested sequencing</a>
+    <b>Related</b>
+    <a href="architecture.html">← Architecture Guide</a>
+</nav>
+<main>
+
+<h1>HolyCluster — Improvement Backlog</h1>
+<p class="subtitle">Ten improvements, <strong>ordered by importance</strong>, from a full-repo architecture review.
+Markdown source: <code>docs/IMPROVEMENTS.md</code> · Background: <a href="architecture.html">architecture.html</a>.
+Every finding was verified against the code; file/line references point at the evidence.</p>
+
+<h2 id="overview">Priority Overview</h2>
+<div class="diagram"><pre class="mermaid">
+quadrantChart
+    title Impact vs. Effort
+    x-axis Low Effort --> High Effort
+    y-axis Low Impact --> High Impact
+    quadrant-1 Plan carefully
+    quadrant-2 Do first
+    quadrant-3 Nice to have
+    quadrant-4 Schedule
+    "1 Fix data retention": [0.2, 0.95]
+    "2 Tests in CI": [0.25, 0.85]
+    "3 Security hardening": [0.3, 0.8]
+    "4 Valkey persistence": [0.2, 0.65]
+    "5 DB backups": [0.35, 0.75]
+    "6 Retire legacy WS": [0.55, 0.55]
+    "7 Repo/docs hygiene": [0.3, 0.45]
+    "8 API limits + logs": [0.2, 0.4]
+    "9 Split draw_map.js": [0.7, 0.5]
+    "10 UTC timestamps": [0.5, 0.4]
+</pre><div class="caption">Items 1–4 and 8 sit in the "do first" quadrant: high impact, hours of effort.</div></div>
+
+<table>
+<tr><th>#</th><th>Improvement</th><th>Category</th><th>Effort</th><th>Risk if ignored</th></tr>
+<tr><td>1</td><td><a href="#i1">Fix broken data-retention &amp; issues-table pipeline</a></td><td>Data integrity</td><td>S</td><td>Unbounded DB growth; broken ops runbook</td></tr>
+<tr><td>2</td><td><a href="#i2">Run the existing test suites in CI</a></td><td>Quality gate</td><td>S</td><td>Regressions ship straight to prod</td></tr>
+<tr><td>3</td><td><a href="#i3">Security hardening (catserver bind, QRZ creds)</a></td><td>Security</td><td>S–M</td><td>LAN radio takeover; credential leak via logs</td></tr>
+<tr><td>4</td><td><a href="#i4">Enable Valkey persistence &amp; graceful degradation</a></td><td>Resilience</td><td>S</td><td>Feature outages after every restart</td></tr>
+<tr><td>5</td><td><a href="#i5">Automated PostgreSQL backups (+ move PGDATA)</a></td><td>Disaster recovery</td><td>M</td><td>Total data loss is one <code>rm -rf</code> away</td></tr>
+<tr><td>6</td><td><a href="#i6">Retire the legacy WebSocket protocols</a></td><td>Simplification</td><td>M</td><td>Dual code paths drift; double maintenance</td></tr>
+<tr><td>7</td><td><a href="#i7">Repository &amp; documentation hygiene</a></td><td>Onboarding</td><td>S</td><td>New engineers follow stale README into dead ends</td></tr>
+<tr><td>8</td><td><a href="#i8">Bound the unbounded API endpoints, drop debug logs</a></td><td>Robustness</td><td>S</td><td>Memory spikes; noisy logs</td></tr>
+<tr><td>9</td><td><a href="#i9">Break up the frontend monoliths, test the map</a></td><td>Maintainability</td><td>L</td><td>Map changes stay high-risk and untestable</td></tr>
+<tr><td>10</td><td><a href="#i10">Unify timestamps on UTC</a></td><td>Correctness</td><td>M</td><td>Subtle time-window bugs, DST edge cases</td></tr>
+</table>
+<p>Effort: S = hours, M = days, L = week+.</p>
+
+<h2 id="i1">1 · Fix the broken data-retention &amp; issues-table pipeline</h2>
+<div class="meta"><span class="tag crit">Critical</span><span class="tag">Data integrity</span><span class="tag">Effort: S</span></div>
+<p>The only known <em>actively broken</em> production defect. Two related failures:</p>
+<ul>
+<li><strong>The retention job crashes on the main table.</strong> <code>backend/collectors/src/collectors/db/cleanup_postgres_tables.py:40</code> deletes rows <code>where(model.date_time &lt; cutoff)</code> for both models, but <code>HolySpot</code> has no <code>date_time</code> column (only <code>time</code> and <code>timestamp</code>). Cleanup of <code>holy_spots2</code> raises <code>AttributeError</code>, so the intended 14-day retention never happens and the table grows without bound. The job isn't in docker-compose either — confirm the external cron actually exists on both servers.</li>
+<li><strong>The issues table is write-dead.</strong> The <code>fix_missing_spot.md</code> runbook and the <code>/spots_with_issues</code> endpoint assume <code>spots_with_issues2</code> is populated, but no code inserts into it — the collector silently drops problematic spots. The team's own debugging procedure no longer works.</li>
+</ul>
+<div class="diagram"><pre class="mermaid">
+flowchart LR
+    subgraph TODAY["Today"]
+        A1["spot fails enrichment"] -->|"dropped silently"| X1["∅ no trace"]
+        B1["cleanup cron"] -->|"AttributeError on&lt;br/&gt;HolySpot.date_time"| X2["holy_spots2 grows forever"]
+    end
+    subgraph FIXED["Fixed"]
+        A2["spot fails enrichment"] -->|"INSERT with issue reason"| T2[("spots_with_issues2")]
+        B2["cleanup job&lt;br/&gt;(in compose or documented cron)"] -->|"WHERE timestamp &lt; cutoff"| T3[("holy_spots2 ≤ 14 days")]
+        T2 -->|"powers the runbook"| OPS["ops debugging"]
+    end
+</pre></div>
+<div class="do">(a) filter on <code>HolySpot.timestamp</code> (epoch int) instead of <code>date_time</code>; (b) re-add the insert into <code>SpotsWithIssues</code> where enrichment fails, with the failure reason; (c) schedule <code>cleanup_postgres</code> explicitly and add a test for it; (d) update <code>fix_missing_spot.md</code> to match reality.</div>
+
+<h2 id="i2">2 · Run the existing test suites in CI</h2>
+<div class="meta"><span class="tag crit">Critical</span><span class="tag">Quality gate</span><span class="tag">Effort: S</span></div>
+<p>Both test suites already exist — CI just never runs them. A push to <code>dev</code> <strong>deploys to the dev server</strong> having only passed linters; a tag deploys to prod the same way.</p>
+<ul>
+<li><code>backend.yml</code> runs only <code>ruff check</code> + <code>ruff format --check</code>; the pytest suites in <code>backend/api/tests/</code> (WebSocket protocol, VOACAP, propagation) and <code>backend/collectors/tests/</code> (parsers, enrichers, geo) are skipped. <code>pytest</code> isn't even a declared dev dependency.</li>
+<li><code>ui.yml</code> runs <code>biome check</code> + <code>vite build</code>, but not <code>vitest</code> — despite 23 test files and an existing <code>npm run check</code> script that does exactly lint+test.</li>
+</ul>
+<div class="diagram"><pre class="mermaid">
+flowchart LR
+    subgraph NOW["Today"]
+        P1["push"] --> L1["lint only"] --> D1["deploy 🚢"]
+    end
+    subgraph TARGET["Target"]
+        P2["push"] --> L2["lint"] --> T2["backend: uv run pytest&lt;br/&gt;ui: vitest run"] --> D2["deploy 🚢"]
+        T2 -->|"fail"| STOP["❌ blocked before the server"]
+    end
+</pre></div>
+<div class="do">add <code>pytest</code> (+ <code>pytest-asyncio</code>) to backend dev dependencies and a <code>uv run pytest</code> step to <code>backend.yml</code>; change <code>ui.yml</code> to <code>npm run check</code>. Then grow coverage where it hurts most: collector enrichment and the <code>/ws</code> protocol.</div>
+
+<h2 id="i3">3 · Security hardening — catserver bind address &amp; QRZ credentials</h2>
+<div class="meta"><span class="tag high">High</span><span class="tag">Security</span><span class="tag">Effort: S–M</span></div>
+<ol>
+<li><strong>catserver listens on <code>0.0.0.0:3000</code></strong> (<code>catserver/src/server.rs:119</code>), not <code>127.0.0.1</code>. Anyone on the operator's LAN (or hostile Wi-Fi) can open the proxied UI, drive the WebSocket, and <strong>transmit-tune the user's radio</strong> — and hit <code>/exit</code> to kill the app. The design only ever needs localhost.</li>
+<li><strong>The QRZ password travels in a URL query string</strong> (<code>backend/shared/src/shared/qrz.py:93</code>). Query strings end up in client logs, proxies, and exception traces. QRZ accepts POST form data; at minimum guarantee the URL never reaches a logger.</li>
+<li><strong>Docker socket mounts</strong> (<code>monitor</code>, <code>nginx_ui</code>) are root-on-host equivalents. <code>nginx_ui</code> is dev-profile-only — good — but <code>monitor</code> runs in prod; consider a read-only socket proxy or document the tradeoff.</li>
+</ol>
+<div class="diagram"><pre class="mermaid">
+flowchart TB
+    subgraph LAN["Operator's home network — today"]
+        EVIL["Any LAN device"] -->|"http://operator-pc:3000"| CS["catserver 0.0.0.0:3000"]
+        CS -->|"SetModeAndFreq"| RADIO["radio transmitter"]
+        CS -->|"POST /exit"| KILL["app killed"]
+    end
+    subgraph FIXEDNET["Fixed"]
+        B2["local browser only"] -->|"127.0.0.1:3000"| CS2["catserver bound to loopback"]
+    end
+</pre></div>
+<div class="do">bind <code>127.0.0.1</code> (keep an opt-in <code>--bind</code> flag for remote-desktop setups); move QRZ auth out of the query string; review docker-socket exposure. Also note <code>nginx-ui/app.ini</code> holds plaintext secrets in the working tree (gitignored, but visible to anyone with tree access).</div>
+
+<h2 id="i4">4 · Enable Valkey persistence &amp; graceful degradation</h2>
+<div class="meta"><span class="tag high">High</span><span class="tag">Resilience</span><span class="tag">Effort: S</span></div>
+<p>The Valkey service has its persistence volume <strong>commented out</strong> (<code>backend/docker-compose.yml:32-34</code>). Every restart — deploy, crash, host reboot — loses:</p>
+<table>
+<tr><th>Lost state</th><th>Consequence</th></tr>
+<tr><td><code>qrz:session_key</code></td><td><code>/locator</code> returns <strong>503</strong> until the collector's hourly refresh</td></tr>
+<tr><td>geo cache</td><td>QRZ hammered with re-lookups; slower enrichment up to 1 h</td></tr>
+<tr><td>dedup keys</td><td>brief duplicate-spot window across sources</td></tr>
+<tr><td><code>stream-api</code> + consumer group</td><td>broadcast gap; clients rely on <code>catch_up</code></td></tr>
+<tr><td><code>stream-arrivals</code></td><td>cluster-stats history truncated</td></tr>
+<tr><td><code>dxpeditions:active</code></td><td><code>/dxpeditions</code> empty until the daily refresh</td></tr>
+</table>
+<div class="diagram"><pre class="mermaid">
+sequenceDiagram
+    participant D as deploy / restart
+    participant V as Valkey (no AOF/RDB)
+    participant A as api
+    participant C as collector
+    D->>V: container restarts — all keys gone
+    A->>V: GET qrz:session_key
+    V-->>A: nil
+    A-->>A: /locator → 503 (up to 1h)
+    C->>C: hourly refresh finally repopulates
+    Note over D,C: With AOF everysec + a volume, none of this happens.
+</pre></div>
+<div class="do">uncomment the data volume and enable <code>appendonly yes</code> in <code>infra/valkey/</code>; independently, make the API request a QRZ session itself when the key is missing instead of 503-ing until the collector's next cycle.</div>
+
+<h2 id="i5">5 · Automated PostgreSQL backups — and move PGDATA out of the repo tree</h2>
+<div class="meta"><span class="tag high">High</span><span class="tag">Disaster recovery</span><span class="tag">Effort: M</span></div>
+<p>There is <strong>no backup mechanism anywhere in the repo</strong>, and the live database files sit <em>inside the git working tree</em> as a bind mount (<code>backend/infra/postgres/data/</code>). The deploy script runs <code>git reset --hard</code> in that same tree on every deploy; gitignore is the only thing separating a routine deploy from data loss. The runbook even documents <code>TRUNCATE TABLE geo_cache;</code> as a casual step — with no restore path if the wrong table is truncated.</p>
+<div class="diagram"><pre class="mermaid">
+flowchart LR
+    subgraph TODAY["Today"]
+        REPO["git working tree&lt;br/&gt;backend/infra/postgres/data ⚠"]
+        DEPLOY["deploy.sh: git reset --hard"] -.->|"one .gitignore mistake away"| REPO
+        REPO -->|"no dumps, no WAL archive"| NORESTORE["❌ no restore path"]
+    end
+    subgraph TARGET["Target"]
+        VOL[("named docker volume&lt;br/&gt;outside the repo")]
+        CRON["nightly pg_dump container"] --> LOCALD["local dumps · 7d"]
+        LOCALD --> OFFSITE["off-site copy (S3/rsync)"]
+        RESTORE["documented + rehearsed restore"] --> VOL
+    end
+</pre></div>
+<div class="do">add a nightly <code>pg_dump</code> sidecar (or host cron) with rotation and an off-site copy; move PGDATA to a named volume or a path outside the repo; write a short <code>docs/restore.md</code> and rehearse it once. Postgres is the only stateful store that can't be regenerated.</div>
+
+<h2 id="i6">6 · Retire the legacy WebSocket protocols</h2>
+<div class="meta"><span class="tag med">Medium</span><span class="tag">Simplification</span><span class="tag">Effort: M</span></div>
+<p>The versioned <code>/ws</code> protocol (v1) replaced older endpoints, but the old ones were never removed. <strong>Four parallel paths</strong> exist across three codebases:</p>
+<div class="diagram"><pre class="mermaid">
+flowchart TB
+    subgraph BACKEND["backend api"]
+        WS1["/ws — v1, multiplexed ✅"]
+        LEG1["/spots_ws — unversioned ⚠"]
+        LEG2["/submit_spot ⚠"]
+        LEG3["/radio — always 'unavailable' ⚠"]
+        BC["broadcast_spots must feed BOTH&lt;br/&gt;active_connections + active_ws_spot_connections"]
+    end
+    subgraph CATS["catserver"]
+        CWS["/ws unified handler ✅"]
+        CLEG["/radio legacy handler +&lt;br/&gt;duplicate command enums ⚠"]
+    end
+    subgraph UI["ui"]
+        UWS["useWs → /ws ✅"]
+        ULEG["SubmitSpot.jsx:38 dead&lt;br/&gt;legacy socket path ⚠"]
+    end
+    WS1 --- CWS
+    CWS --- UWS
+</pre><div class="caption">Every spots broadcast is duplicated to two connection sets; catserver maintains two near-identical command enums; the UI ships dead socket code.</div></div>
+<p>Old catserver installations are the main reason the legacy endpoints survive — which is exactly why the catserver auto-update nudge matters.</p>
+<div class="do">log per-endpoint connection counts for a few weeks; then delete the UI dead path (free), remove catserver's <code>/radio</code> handler and duplicate enum, and finally remove the backend legacy endpoints (or return a "please update" close code). End state: one protocol, one broadcast set, one enum.</div>
+
+<h2 id="i7">7 · Repository &amp; documentation hygiene</h2>
+<div class="meta"><span class="tag med">Medium</span><span class="tag">Onboarding</span><span class="tag">Effort: S</span></div>
+<p>Individually small, collectively the first impression every new engineer gets:</p>
+<ul>
+<li><strong>README is wrong.</strong> It instructs <code>pip install -e '.[omnirig]'</code> and <code>python src/ClientSideServer.py</code> (<code>README.md:53,58</code>) — neither exists; the Rust catserver replaced them, and the backend moved to uv + docker compose long ago.</li>
+<li><strong>~120 MB of log files at repo root</strong> (<code>compose_logs_int_3.txt</code> 41 MB, <code>compose_logs_int_4.txt</code> 79 MB) — untracked but not gitignored, polluting <code>git status</code>.</li>
+<li><strong>Shadow infra trees</strong> at the root (<code>nginx/</code>, <code>certbot/</code>, <code>postgres/</code>, <code>nginx-ui/</code>) shadow the authoritative <code>backend/infra/</code> — an edit-the-wrong-file trap.</li>
+<li><strong><code>nginx.conf</code> vs template drift</strong>: only the template is rendered at runtime; the committed rendered copy differs and misleads.</li>
+<li>Minor: leftover debug log lines (see #8), the WiX installer's registry keypath under boilerplate <code>Software\MyCompany\MyApp</code> (<code>catserver/wix/main.wxs:122-124</code>), <code>publish.sh:22</code> <code>exit1</code> typo.</li>
+</ul>
+<div class="do">rewrite the README around the three real components (condensed from the architecture guide); delete the logs and gitignore <code>compose_logs*</code>; add pointers from the shadow trees to <code>backend/infra/</code>; delete or CI-regenerate the stale rendered <code>nginx.conf</code>; fix the WiX keypath.</div>
+
+<h2 id="i8">8 · Bound the unbounded API endpoints &amp; remove debug leftovers</h2>
+<div class="meta"><span class="tag med">Medium</span><span class="tag">Robustness</span><span class="tag">Effort: S</span></div>
+<ul>
+<li><code>GET /geocache/all</code> (<code>api/main.py:594</code>) serializes the <strong>entire</strong> <code>geo_cache</code> table — no limit, no pagination — into memory per request. A refresh loop or crawler can spike API memory/CPU.</li>
+<li><code>GET /spots_with_issues</code> (<code>api/main.py:612</code>) is the same pattern (currently returns <code>[]</code> only because of defect #1 — fixing #1 makes this unbounded too).</li>
+<li><code>/history</code> contains leftover debug logging: <code>logger.info("test 1s")</code>, <code>logger.info("test")</code> (<code>api/main.py:1068,1071</code>).</li>
+<li>No rate limiting anywhere; nginx is the natural place for a basic <code>limit_req</code> on <code>/voacap</code> and <code>/history</code>.</li>
+</ul>
+<div class="do">add <code>limit</code>/<code>offset</code> (sane default and max) to both dump endpoints — or restrict them to internal use; delete the debug lines; add a modest nginx <code>limit_req</code> zone for the expensive endpoints.</div>
+
+<h2 id="i9">9 · Break up the frontend monoliths &amp; test the map engine</h2>
+<div class="meta"><span class="tag med">Medium</span><span class="tag">Maintainability</span><span class="tag">Effort: L</span></div>
+<p>The map — the product's core — is concentrated in a handful of giant, effectively untested files:</p>
+<div class="diagram"><pre class="mermaid">
+flowchart LR
+    subgraph HOT["Complexity hot spots (lines)"]
+        DM["draw_map.js — 1546"]
+        ST["SpotsTable.jsx — 908"]
+        MC["MapControls.jsx — 774"]
+        HP["HunterPanel.jsx — 729"]
+        MG["useMapGestures.js — 602"]
+    end
+    TESTS["ui/tests — 23 files&lt;br/&gt;cover data/utils + a few components&lt;br/&gt;❌ zero coverage of canvas drawing,&lt;br/&gt;projections, gestures, hit-testing"]
+    HOT -.->|"every change is a&lt;br/&gt;manual-QA-only change"| RISK["high regression risk"]
+</pre></div>
+<p><code>draw_map.js</code> alone contains country fills, the adaptive Maidenhead grid + labels, CQ/ITU zones, DXCC strokes, the equator, and the day/night terminator. The animation loop reads a mutable <code>render_state_ref</code> outside React's model — correct today, but a stale-closure magnet.</p>
+<div class="do">incrementally, not a rewrite: split <code>draw_map.js</code> by layer (<code>draw_countries.js</code>, <code>draw_grid.js</code>, <code>draw_zones.js</code>, <code>draw_night.js</code>) — the seams already exist as top-level functions; extract and unit-test the pure geometry/label-placement helpers (no canvas needed); add a couple of golden-image canvas tests for the main draw paths; document the <code>render_state_ref</code> contract.</div>
+
+<h2 id="i10">10 · Unify timestamps on UTC</h2>
+<div class="meta"><span class="tag low">Lower</span><span class="tag">Correctness</span><span class="tag">Effort: M</span></div>
+<p>Spot timestamps mix timezone bases: <code>add_spot_to_postgres</code> builds <code>HolySpot.time</code> with local-time <code>datetime.fromtimestamp(...)</code> while <code>timestamp</code> is a UTC epoch (<code>collectors/main.py:118</code>), and the containers pin <code>TZ=Asia/Jerusalem</code>. The API's time-window queries and the UI's 1-hour trim all reason in epoch/UTC.</p>
+<p>Consequences: the string <code>time</code> column disagrees with <code>timestamp</code> by the server's UTC offset; DST shifts it twice a year; anyone comparing <code>time</code> against a UTC source (or running with a different host TZ) gets subtly wrong windows — and the dedup key includes <code>time</code>.</p>
+<div class="do">write UTC everywhere (<code>datetime.fromtimestamp(ts, tz=timezone.utc)</code>); treat epoch <code>timestamp</code> as the single source of truth and derive display strings client-side; keep <code>TZ</code> pinning only for log readability; document the cutover date (backfill optional).</div>
+
+<h2 id="seq">Suggested sequencing</h2>
+<div class="diagram"><pre class="mermaid">
+gantt
+    dateFormat X
+    axisFormat %s
+    section Week 1 — stop the bleeding
+        1 Retention fix           :a1, 0, 2
+        2 Tests in CI             :a2, 0, 2
+        4 Valkey persistence      :a3, 2, 3
+        8 API limits + debug logs :a4, 2, 3
+    section Week 2–3 — safety net
+        3 Security hardening      :b1, 3, 5
+        5 Backups + PGDATA move   :b2, 5, 8
+        7 Repo/docs hygiene       :b3, 3, 5
+    section Month 2 — structural
+        6 Retire legacy WS        :c1, 8, 12
+        10 UTC timestamps         :c2, 8, 11
+        9 Frontend refactor       :c3, 11, 16
+</pre><div class="caption">Items 1, 2, 4, 8 are hours each and remove the most acute risks. Items 3, 5, 7 build the safety net. Items 6, 9, 10 are structural and benefit from the test gate (#2) landing first.</div></div>
+
+<p style="margin-top:48px;color:var(--muted);font-size:13px;">Generated from a full-repo architecture review · July 2026 · Diagrams require internet access (Mermaid via CDN); the same diagrams are in <code>docs/IMPROVEMENTS.md</code>.</p>
+</main>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script>
+    mermaid.initialize({
+        startOnLoad: true,
+        securityLevel: "loose",
+        theme: window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "default",
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `docs/ARCHITECTURE.md` + `docs/architecture.html`: a maintainer-oriented guide to the whole system (collector pipeline, API/WebSocket protocol, React canvas-map frontend, catserver, infra/CI/CD), with mermaid diagrams throughout.
- Adds `docs/IMPROVEMENTS.md` + `docs/improvements.html`: ten improvements ranked by importance, each with code evidence (file:line) and diagrams. Top items are active defects: broken retention cleanup (`HolySpot.date_time` doesn't exist), no tests running in CI, catserver binding `0.0.0.0:3000`, Valkey persistence disabled, no DB backups.

The HTML pages are standalone (sidebar nav, light/dark) and render diagrams via the Mermaid CDN; the markdown versions render natively on GitHub. All 48 diagram blocks were validated against the Mermaid 11 parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112eA8aHj5BDu4PTKwLnNmc