### PR TITLE
Run CI checks on pull requests targeting dev

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,12 +9,18 @@ on:
       - "dev"
     tags:
       - "backend-v*"
+  pull_request:
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend.yml"
+    branches:
+      - "dev"
 
 jobs:
   build-and-deploy-backend:
     name: Lint and Deploy Backend
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/backend-v')
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/backend-v')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,6 +54,7 @@ jobs:
           uv run pytest
 
       - name: Setup SSH
+        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/backend-v')
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa

--- a/.github/workflows/catserver.yml
+++ b/.github/workflows/catserver.yml
@@ -9,6 +9,12 @@ on:
       - "dev"
     tags:
       - "catserver-v*"
+  pull_request:
+    paths:
+      - "catserver/**"
+      - ".github/workflows/catserver.yml"
+    branches:
+      - "dev"
 
 env:
   TARGET: x86_64-pc-windows-gnu
@@ -27,6 +33,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup SSH
+        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
         run: |
           export HOME=/root
           mkdir -p $HOME/.ssh

--- a/.github/workflows/catserver.yml
+++ b/.github/workflows/catserver.yml
@@ -79,10 +79,12 @@ jobs:
         run: cargo build --target $TARGET --release
 
       - name: Change build artifacts ownership
+        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
         working-directory: ./catserver
         run: chown -R wix:wix target
 
       - name: Build installer
+        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
         working-directory: ./catserver
         run: su wix -c "./build_msi.sh in-docker --default-shortcut-arguments '${DEFAULT_SHORTCUT_ARGUMENTS}'"
         env:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -9,12 +9,18 @@ on:
       - "dev"
     tags:
       - "v*"
+  pull_request:
+    paths:
+      - "ui/**"
+      - ".github/workflows/ui.yml"
+    branches:
+      - "dev"
 
 jobs:
   build-and-deploy-ui:
     name: Build, Lint, and Deploy the UI
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,6 +53,7 @@ jobs:
           npm run build
 
       - name: Setup SSH
+        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa


### PR DESCRIPTION
Adds a `pull_request` trigger (mirroring the existing `push` paths/branch filters) to `ui.yml`, `backend.yml`, and `catserver.yml`, and widens the job-level `if:` gate in `ui.yml`/`backend.yml` so lint/test/build actually run for PR events (previously the job-level guard only matched `refs/heads/dev` or tags, so PRs got zero checks even if a trigger existed).

Deploy/upload steps keep their existing per-step `if:` guards (checked against `github.ref`), which naturally stay false for `pull_request` events — so PRs build/lint/test but never deploy. Also scoped the previously-unconditional `Setup SSH` step in each workflow to only run when a deploy could actually happen, so PR runs don't touch deploy secrets at all.