### PR TITLE
Support generic artifact publishing

### DIFF
--- a/.github/workflows/catserver.yml
+++ b/.github/workflows/catserver.yml
@@ -129,8 +129,8 @@ jobs:
           bash catserver/publish.sh \
             --deploy-user ${{ secrets.DEPLOY_USER_DEV }} \
             --deploy-host ${{ secrets.DEPLOY_HOST_DEV }} \
-            --local-msi-path catserver/target/$TARGET/release/HolyCluster.msi \
-            --remote-msi-dir /opt/msi
+            --local-artifact-path catserver/target/$TARGET/release/HolyCluster.msi \
+            --remote-artifact-dir /opt/msi
 
       - name: Upload to Production Server
         if: startsWith(github.ref, 'refs/tags/')
@@ -138,5 +138,5 @@ jobs:
           bash catserver/publish.sh \
             --deploy-user ${{ secrets.DEPLOY_USER_PROD }} \
             --deploy-host ${{ secrets.DEPLOY_HOST_PROD }} \
-            --local-msi-path catserver/target/$TARGET/release/HolyCluster.msi \
-            --remote-msi-dir /opt/msi
+            --local-artifact-path catserver/target/$TARGET/release/HolyCluster.msi \
+            --remote-artifact-dir /opt/msi

--- a/catserver/publish.sh
+++ b/catserver/publish.sh
@@ -11,12 +11,6 @@ main() {
             --deploy-host)
                 DEPLOY_HOST="$2"
                 ;;
-            --local-msi-path)
-                LOCAL_ARTIFACT_PATH="$2"
-                ;;
-            --remote-msi-dir)
-                REMOTE_ARTIFACT_DIR="$2"
-                ;;
             --local-artifact-path)
                 LOCAL_ARTIFACT_PATH="$2"
                 ;;

--- a/catserver/publish.sh
+++ b/catserver/publish.sh
@@ -12,10 +12,22 @@ main() {
                 DEPLOY_HOST="$2"
                 ;;
             --local-msi-path)
-                LOCAL_MSI_PATH="$2"
+                LOCAL_ARTIFACT_PATH="$2"
                 ;;
             --remote-msi-dir)
-                REMOTE_MSI_DIR="$2"
+                REMOTE_ARTIFACT_DIR="$2"
+                ;;
+            --local-artifact-path)
+                LOCAL_ARTIFACT_PATH="$2"
+                ;;
+            --remote-artifact-dir)
+                REMOTE_ARTIFACT_DIR="$2"
+                ;;
+            --artifact-name)
+                ARTIFACT_NAME="$2"
+                ;;
+            --latest-file)
+                LATEST_FILE="$2"
                 ;;
             *)
                 echo Unknown arg: $1
@@ -28,12 +40,13 @@ main() {
 
     chown -R $(id -u):$(id -g) .
 
-    MSI_NAME=$(git describe --match 'catserver-v*').msi
+    ARTIFACT_NAME=${ARTIFACT_NAME:-$(git describe --match 'catserver-v*').msi}
+    LATEST_FILE=${LATEST_FILE:-latest}
 
-    echo Copying msi $MSI_NAME
-    scp $LOCAL_MSI_PATH $DEPLOY_USER@$DEPLOY_HOST:$REMOTE_MSI_DIR/$MSI_NAME
+    echo Copying artifact $ARTIFACT_NAME
+    scp "$LOCAL_ARTIFACT_PATH" "$DEPLOY_USER@$DEPLOY_HOST:$REMOTE_ARTIFACT_DIR/$ARTIFACT_NAME"
     echo Updating latest version
-    ssh $DEPLOY_USER@$DEPLOY_HOST "echo $MSI_NAME > $REMOTE_MSI_DIR/latest"
+    ssh "$DEPLOY_USER@$DEPLOY_HOST" "echo $ARTIFACT_NAME > $REMOTE_ARTIFACT_DIR/$LATEST_FILE"
 }
 
 main $@


### PR DESCRIPTION
## Summary
- add generic artifact path, name, and latest-pointer options to the catserver publisher
- retain existing MSI flags and default Windows publication behavior

## Validation
- `bash -n catserver/publish.sh`
- `git diff --check`

## Risk
- Linux workflow integration is intentionally deferred; existing Windows callers use the retained legacy flags.