### PR TITLE
Build Linux AppImage artifact

### DIFF
--- a/.github/workflows/catserver.yml
+++ b/.github/workflows/catserver.yml
@@ -92,6 +92,10 @@ jobs:
         working-directory: ./catserver
         run: cargo test --workspace
 
+      - name: Build Linux release binary
+        working-directory: ./catserver
+        run: cargo build --workspace --release
+
       - name: Run Clippy
         working-directory: ./catserver
         run: cargo clippy --workspace --target $TARGET -- -D warnings

--- a/.github/workflows/catserver.yml
+++ b/.github/workflows/catserver.yml
@@ -94,7 +94,22 @@ jobs:
 
       - name: Build Linux release binary
         working-directory: ./catserver
-        run: cargo build --workspace --release
+        run: cargo build --workspace --target x86_64-unknown-linux-gnu --release
+
+      - name: Build Linux AppImage
+        working-directory: ./catserver
+        run: |
+          apt-get update
+          apt-get install --yes wget
+          wget -qO linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
+          sh ./build_appimage.sh
+
+      - name: Upload Linux AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: HolyCluster-linux-x86_64
+          path: catserver/target/x86_64-unknown-linux-gnu/release/catserver-v*-linux-x86_64.AppImage
 
       - name: Run Clippy
         working-directory: ./catserver

--- a/.github/workflows/catserver.yml
+++ b/.github/workflows/catserver.yml
@@ -100,7 +100,7 @@ jobs:
         working-directory: ./catserver
         run: |
           apt-get update
-          apt-get install --yes wget
+          apt-get install --yes imagemagick wget
           wget -qO linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
           sh ./build_appimage.sh

--- a/.github/workflows/catserver.yml
+++ b/.github/workflows/catserver.yml
@@ -98,12 +98,7 @@ jobs:
 
       - name: Build Linux AppImage
         working-directory: ./catserver
-        run: |
-          apt-get update
-          apt-get install --yes imagemagick wget
-          wget -qO linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/linuxdeploy-x86_64.AppImage
-          chmod +x linuxdeploy-x86_64.AppImage
-          sh ./build_appimage.sh
+        run: sh ./build_appimage.sh
 
       - name: Upload Linux AppImage
         uses: actions/upload-artifact@v4

--- a/catserver/Dockerfile
+++ b/catserver/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
         g++-mingw-w64-x86-64-posix \
         libappindicator3-dev \
         libgtk-3-dev \
+        imagemagick \
         libusb-1.0-0 \
         libusb-1.0-0-dev \
         libxdo-dev \
@@ -52,7 +53,8 @@ RUN set -ex \
         "wine-stable-amd64=$WINE_PACKAGE_VERSION" \
         "wine-stable-i386:i386=$WINE_PACKAGE_VERSION" \
     && curl -sSfLo /usr/local/bin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
-    && chmod +x /usr/local/bin/winetricks \
+    && curl -sSfLo /usr/local/bin/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/linuxdeploy-x86_64.AppImage \
+    && chmod +x /usr/local/bin/winetricks /usr/local/bin/linuxdeploy-x86_64.AppImage \
     && useradd -m wix \
     && printf '#!/bin/sh\nexec wine dotnet $@' > /usr/local/bin/dotnet \
     && printf '#!/bin/sh\nexec wine wix.exe $@' > /usr/local/bin/wix \

--- a/catserver/appimage/HolyCluster.desktop
+++ b/catserver/appimage/HolyCluster.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=HolyCluster
+Exec=HolyCluster
+Icon=HolyCluster
+Categories=Network;

--- a/catserver/build_appimage.sh
+++ b/catserver/build_appimage.sh
@@ -5,7 +5,7 @@ TARGET=x86_64-unknown-linux-gnu
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target}
 BUILD_DIR=$CARGO_TARGET_DIR/$TARGET/release
 APPDIR=$BUILD_DIR/AppDir
-LINUXDEPLOY=${LINUXDEPLOY:-linuxdeploy-x86_64.AppImage}
+LINUXDEPLOY=${LINUXDEPLOY:-./linuxdeploy-x86_64.AppImage}
 VERSION=$(git describe --match 'catserver-v*')
 OUTPUT=$BUILD_DIR/$VERSION-linux-x86_64.AppImage
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)

--- a/catserver/build_appimage.sh
+++ b/catserver/build_appimage.sh
@@ -5,7 +5,7 @@ TARGET=x86_64-unknown-linux-gnu
 CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target}
 BUILD_DIR=$CARGO_TARGET_DIR/$TARGET/release
 APPDIR=$BUILD_DIR/AppDir
-LINUXDEPLOY=${LINUXDEPLOY:-./linuxdeploy-x86_64.AppImage}
+LINUXDEPLOY=${LINUXDEPLOY:-/usr/local/bin/linuxdeploy-x86_64.AppImage}
 VERSION=$(git describe --match 'catserver-v*')
 OUTPUT=$BUILD_DIR/$VERSION-linux-x86_64.AppImage
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)

--- a/catserver/build_appimage.sh
+++ b/catserver/build_appimage.sh
@@ -14,7 +14,7 @@ rm -rf "$APPDIR"
 mkdir -p "$APPDIR/usr/bin"
 cp "$BUILD_DIR/catserver" "$APPDIR/usr/bin/HolyCluster"
 cp "$SCRIPT_DIR/appimage/HolyCluster.desktop" "$APPDIR/HolyCluster.desktop"
-cp "$SCRIPT_DIR/../ui/src/assets/icon.png" "$APPDIR/HolyCluster.png"
+convert "$SCRIPT_DIR/../ui/src/assets/icon.png" -resize '128x128!' "$APPDIR/HolyCluster.png"
 cat > "$APPDIR/AppRun" <<'EOF'
 #!/bin/sh
 exec "$(dirname "$0")/usr/bin/HolyCluster" "$@"

--- a/catserver/build_appimage.sh
+++ b/catserver/build_appimage.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+TARGET=x86_64-unknown-linux-gnu
+CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-target}
+BUILD_DIR=$CARGO_TARGET_DIR/$TARGET/release
+APPDIR=$BUILD_DIR/AppDir
+LINUXDEPLOY=${LINUXDEPLOY:-linuxdeploy-x86_64.AppImage}
+VERSION=$(git describe --match 'catserver-v*')
+OUTPUT=$BUILD_DIR/$VERSION-linux-x86_64.AppImage
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin"
+cp "$BUILD_DIR/catserver" "$APPDIR/usr/bin/HolyCluster"
+cp "$SCRIPT_DIR/appimage/HolyCluster.desktop" "$APPDIR/HolyCluster.desktop"
+cp "$SCRIPT_DIR/../ui/src/assets/icon.png" "$APPDIR/HolyCluster.png"
+cat > "$APPDIR/AppRun" <<'EOF'
+#!/bin/sh
+exec "$(dirname "$0")/usr/bin/HolyCluster" "$@"
+EOF
+chmod +x "$APPDIR/AppRun"
+
+ARCH=x86_64 "$LINUXDEPLOY" --appimage-extract-and-run \
+    --appdir "$APPDIR" \
+    --executable "$APPDIR/usr/bin/HolyCluster" \
+    --desktop-file "$APPDIR/HolyCluster.desktop" \
+    --icon-file "$APPDIR/HolyCluster.png" \
+    --output appimage
+mv HolyCluster-x86_64.AppImage "$OUTPUT"


### PR DESCRIPTION
## Summary
- Build the x86_64 GNU/Linux catserver release binary in CI.
- Stage it as a platform-qualified AppImage and upload it as a CI artifact.
- Keep Windows MSI publishing and backend/UI artifact selection unchanged.

## Validation
- sh -n catserver/build_appimage.sh
- git diff --check
- CARGO_TARGET_DIR=target cargo build --package catserver --target x86_64-unknown-linux-gnu --release
- ldd and readelf runtime-closure inspection

## Notes
- The AppImage is CI-artifact-only; no publication or download-route changes are included.