### PR TITLE
Configure rigctld endpoints

### DIFF
--- a/catserver/src/application.rs
+++ b/catserver/src/application.rs
@@ -3,7 +3,7 @@ use single_instance::SingleInstance;
 use tokio::sync::broadcast::{self, Sender};
 
 use crate::{
-    args::{Args, BASE_LOCAL_PORT, server_config},
+    args::{Args, BASE_LOCAL_PORT, rigctld_endpoint, server_config},
     dummy_rotator::DummyRotator,
     radio_config::RadioConfig,
     radio_factory,
@@ -29,6 +29,7 @@ pub fn run() -> Result<()> {
             "Radio configuration is invalid; using the platform default for this session"
         );
     }
+    let rigctld_endpoint = rigctld_endpoint(&args);
     let radio = radio(radio_config.config, args.dummy)?;
     let rotator = rotator(args.dummy_rotator);
     if instance.is_single() {
@@ -43,7 +44,14 @@ pub fn run() -> Result<()> {
             .name("singleton".into())
             .spawn(move || {
                 if let Err(error) =
-                    run_singleton(event_sender, radio, rotator, server_config, use_local_ui)
+                    run_singleton(
+                        event_sender,
+                        radio,
+                        rotator,
+                        server_config,
+                        use_local_ui,
+                        rigctld_endpoint,
+                    )
                 {
                     tracing::error!(?error, "Singleton instance failed");
                 }
@@ -104,10 +112,15 @@ async fn run_singleton(
     rotator: AnyRotator,
     server_config: ServerConfig,
     use_local_ui: bool,
+    rigctld_endpoint: (String, u16),
 ) -> Result<()> {
     let snapshot = radio.snapshot();
     let selected = snapshot.selected.clone();
-    let factory = radio_factory::factory(snapshot.config.clone(), selected.clone());
+    let factory = radio_factory::factory(
+        snapshot.config.clone(),
+        selected.clone(),
+        rigctld_endpoint,
+    );
     radio
         .replace(snapshot.config, selected, move || factory())
         .await?;

--- a/catserver/src/application.rs
+++ b/catserver/src/application.rs
@@ -114,8 +114,11 @@ async fn run_singleton(
 ) -> Result<()> {
     let snapshot = radio.snapshot();
     let selected = snapshot.selected.clone();
-    let factory =
-        radio_factory::factory(snapshot.config.clone(), selected.clone(), rigctld_endpoint);
+    let factory = radio_factory::factory_with_rigctld_endpoint(
+        snapshot.config.clone(),
+        selected.clone(),
+        rigctld_endpoint,
+    );
     radio
         .replace(snapshot.config, selected, move || factory())
         .await?;

--- a/catserver/src/application.rs
+++ b/catserver/src/application.rs
@@ -114,11 +114,8 @@ async fn run_singleton(
 ) -> Result<()> {
     let snapshot = radio.snapshot();
     let selected = snapshot.selected.clone();
-    let factory = radio_factory::factory_with_rigctld_endpoint(
-        snapshot.config.clone(),
-        selected.clone(),
-        rigctld_endpoint,
-    );
+    let factory =
+        radio_factory::factory(snapshot.config.clone(), selected.clone(), rigctld_endpoint);
     radio
         .replace(snapshot.config, selected, move || factory())
         .await?;

--- a/catserver/src/application.rs
+++ b/catserver/src/application.rs
@@ -43,16 +43,14 @@ pub fn run() -> Result<()> {
         let thread = std::thread::Builder::new()
             .name("singleton".into())
             .spawn(move || {
-                if let Err(error) =
-                    run_singleton(
-                        event_sender,
-                        radio,
-                        rotator,
-                        server_config,
-                        use_local_ui,
-                        rigctld_endpoint,
-                    )
-                {
+                if let Err(error) = run_singleton(
+                    event_sender,
+                    radio,
+                    rotator,
+                    server_config,
+                    use_local_ui,
+                    rigctld_endpoint,
+                ) {
                     tracing::error!(?error, "Singleton instance failed");
                 }
             })?;
@@ -116,11 +114,8 @@ async fn run_singleton(
 ) -> Result<()> {
     let snapshot = radio.snapshot();
     let selected = snapshot.selected.clone();
-    let factory = radio_factory::factory(
-        snapshot.config.clone(),
-        selected.clone(),
-        rigctld_endpoint,
-    );
+    let factory =
+        radio_factory::factory(snapshot.config.clone(), selected.clone(), rigctld_endpoint);
     radio
         .replace(snapshot.config, selected, move || factory())
         .await?;

--- a/catserver/src/args.rs
+++ b/catserver/src/args.rs
@@ -3,6 +3,8 @@ use argh::FromArgs;
 use crate::server::ServerConfig;
 
 pub const BASE_LOCAL_PORT: u16 = 3000;
+pub const DEFAULT_RIGCTLD_HOST: &str = "127.0.0.1";
+pub const DEFAULT_RIGCTLD_PORT: u16 = 4532;
 
 #[derive(FromArgs)]
 /// The Holy Cluster - debug flags
@@ -23,6 +25,12 @@ pub struct Args {
     /// port for local connection
     #[argh(option)]
     pub port: Option<u16>,
+    /// rigctld host
+    #[argh(option)]
+    pub rigctld_host: Option<String>,
+    /// rigctld port
+    #[argh(option)]
+    pub rigctld_port: Option<u16>,
     /// closes the running instance
     #[argh(switch)]
     pub close: bool,
@@ -40,4 +48,13 @@ pub fn server_config(args: &Args) -> ServerConfig {
         is_using_ssl: true,
         local_port,
     }
+}
+
+pub fn rigctld_endpoint(args: &Args) -> (String, u16) {
+    (
+        args.rigctld_host
+            .clone()
+            .unwrap_or_else(|| DEFAULT_RIGCTLD_HOST.into()),
+        args.rigctld_port.unwrap_or(DEFAULT_RIGCTLD_PORT),
+    )
 }

--- a/catserver/src/radio_factory.rs
+++ b/catserver/src/radio_factory.rs
@@ -33,6 +33,8 @@ fn build(
     selected: &ActiveRadioBackend,
     rigctld_endpoint: &(String, u16),
 ) -> Box<dyn Radio> {
+    #[cfg(windows)]
+    let _ = rigctld_endpoint;
     match selected {
         ActiveRadioBackend::Dummy => Box::new(DummyRadio::new()),
         ActiveRadioBackend::Configured(RadioBackendKind::Hamlib) => config

--- a/catserver/src/radio_factory.rs
+++ b/catserver/src/radio_factory.rs
@@ -35,12 +35,10 @@ fn build(
         #[cfg(windows)]
         ActiveRadioBackend::Configured(RadioBackendKind::Omnirig) => Box::new(OmnirigRadio::new()),
         #[cfg(not(windows))]
-        ActiveRadioBackend::Configured(RadioBackendKind::Rigctld) => {
-            Box::new(RigctldRadio::new(
-                rigctld_endpoint.0.clone(),
-                rigctld_endpoint.1,
-            ))
-        }
+        ActiveRadioBackend::Configured(RadioBackendKind::Rigctld) => Box::new(RigctldRadio::new(
+            rigctld_endpoint.0.clone(),
+            rigctld_endpoint.1,
+        )),
         ActiveRadioBackend::Configured(backend) => Box::new(UnavailableRadio::new(match backend {
             RadioBackendKind::Omnirig => "omnirig",
             RadioBackendKind::Rigctld => "rigctld",

--- a/catserver/src/radio_factory.rs
+++ b/catserver/src/radio_factory.rs
@@ -1,5 +1,4 @@
 use crate::{
-    args::{DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_PORT},
     dummy::DummyRadio,
     hamlib_radio::HamlibRadio,
     radio_actor::RadioFactory,
@@ -12,15 +11,7 @@ use crate::omnirig::OmnirigRadio;
 #[cfg(not(windows))]
 use crate::rigctld::RigctldRadio;
 
-pub(crate) fn factory(config: RadioConfig, selected: ActiveRadioBackend) -> RadioFactory {
-    factory_with_rigctld_endpoint(
-        config,
-        selected,
-        (DEFAULT_RIGCTLD_HOST.into(), DEFAULT_RIGCTLD_PORT),
-    )
-}
-
-pub(crate) fn factory_with_rigctld_endpoint(
+pub(crate) fn factory(
     config: RadioConfig,
     selected: ActiveRadioBackend,
     rigctld_endpoint: (String, u16),

--- a/catserver/src/radio_factory.rs
+++ b/catserver/src/radio_factory.rs
@@ -11,11 +11,19 @@ use crate::omnirig::OmnirigRadio;
 #[cfg(not(windows))]
 use crate::rigctld::RigctldRadio;
 
-pub(crate) fn factory(config: RadioConfig, selected: ActiveRadioBackend) -> RadioFactory {
-    std::sync::Arc::new(move || build(&config, &selected))
+pub(crate) fn factory(
+    config: RadioConfig,
+    selected: ActiveRadioBackend,
+    rigctld_endpoint: (String, u16),
+) -> RadioFactory {
+    std::sync::Arc::new(move || build(&config, &selected, &rigctld_endpoint))
 }
 
-fn build(config: &RadioConfig, selected: &ActiveRadioBackend) -> Box<dyn Radio> {
+fn build(
+    config: &RadioConfig,
+    selected: &ActiveRadioBackend,
+    rigctld_endpoint: &(String, u16),
+) -> Box<dyn Radio> {
     match selected {
         ActiveRadioBackend::Dummy => Box::new(DummyRadio::new()),
         ActiveRadioBackend::Configured(RadioBackendKind::Hamlib) => config
@@ -28,7 +36,10 @@ fn build(config: &RadioConfig, selected: &ActiveRadioBackend) -> Box<dyn Radio> 
         ActiveRadioBackend::Configured(RadioBackendKind::Omnirig) => Box::new(OmnirigRadio::new()),
         #[cfg(not(windows))]
         ActiveRadioBackend::Configured(RadioBackendKind::Rigctld) => {
-            Box::new(RigctldRadio::new("localhost".into(), 4532))
+            Box::new(RigctldRadio::new(
+                rigctld_endpoint.0.clone(),
+                rigctld_endpoint.1,
+            ))
         }
         ActiveRadioBackend::Configured(backend) => Box::new(UnavailableRadio::new(match backend {
             RadioBackendKind::Omnirig => "omnirig",

--- a/catserver/src/radio_factory.rs
+++ b/catserver/src/radio_factory.rs
@@ -1,4 +1,5 @@
 use crate::{
+    args::{DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_PORT},
     dummy::DummyRadio,
     hamlib_radio::HamlibRadio,
     radio_actor::RadioFactory,
@@ -11,7 +12,15 @@ use crate::omnirig::OmnirigRadio;
 #[cfg(not(windows))]
 use crate::rigctld::RigctldRadio;
 
-pub(crate) fn factory(
+pub(crate) fn factory(config: RadioConfig, selected: ActiveRadioBackend) -> RadioFactory {
+    factory_with_rigctld_endpoint(
+        config,
+        selected,
+        (DEFAULT_RIGCTLD_HOST.into(), DEFAULT_RIGCTLD_PORT),
+    )
+}
+
+pub(crate) fn factory_with_rigctld_endpoint(
     config: RadioConfig,
     selected: ActiveRadioBackend,
     rigctld_endpoint: (String, u16),

--- a/catserver/src/server/radio_configuration.rs
+++ b/catserver/src/server/radio_configuration.rs
@@ -3,6 +3,7 @@ use std::{future::Future, pin::Pin, sync::Arc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    args::{DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_PORT},
     radio_config::{HamlibConfig, HamlibRigConfig, RadioBackendKind, RadioConfig},
     radio_factory,
     radio_manager::RadioManager,
@@ -108,7 +109,11 @@ impl RadioConfigurationService for ProductionRadioConfiguration {
                 };
             }
             let selected = configuration.effective_backend(false);
-            let factory = radio_factory::factory(configuration.clone(), selected.clone());
+            let factory = radio_factory::factory(
+                configuration.clone(),
+                selected.clone(),
+                (DEFAULT_RIGCTLD_HOST.into(), DEFAULT_RIGCTLD_PORT),
+            );
             match self
                 .radio
                 .replace_and_persist(configuration, selected, move || factory())


### PR DESCRIPTION
## Summary
- add CLI host and port options for the Linux rigctld backend
- retain loopback defaults at 127.0.0.1:4532
- reuse the configured endpoint for radio backend retries

## Validation
- `git diff --check origin/dev...HEAD`

## Risks / follow-up
- Cargo tests were not run because they require separate approval.