### PR TITLE
Add metadata-driven CAT settings

### DIFF
--- a/catserver/src/hamlib_radio.rs
+++ b/catserver/src/hamlib_radio.rs
@@ -1,20 +1,20 @@
 use crate::{
     freq::Freq,
-    radio_config::{HamlibConfig, HamlibRigConfig},
+    radio_config::HamlibRigConfig,
     rig::{Mode, Radio, RadioInitError, Slot, Status},
 };
 
 pub(crate) struct HamlibRadio {
-    config: HamlibConfig,
+    config: [Option<HamlibRigConfig>; 2],
     rigs: [Option<hamlib::Rig<hamlib::Open>>; 2],
     current_rig: u8,
     failures: u8,
 }
 
 impl HamlibRadio {
-    pub(crate) fn new(config: HamlibConfig) -> Self {
+    pub(crate) fn new(rig1: HamlibRigConfig, rig2: Option<HamlibRigConfig>) -> Self {
         Self {
-            config,
+            config: [Some(rig1), rig2],
             rigs: [None, None],
             current_rig: 1,
             failures: 0,
@@ -39,10 +39,12 @@ impl HamlibRadio {
 impl Radio for HamlibRadio {
     fn init(&mut self) -> Result<(), RadioInitError> {
         self.rigs = [None, None];
-        let rig1 = open(&self.config.rig1).map_err(|error| init_error(1, error))?;
+        let rig1 = open(self.config[0].as_ref().expect("rig 1 configuration"))
+            .map_err(|error| init_error(1, error))?;
         let rig2 = self
             .config
-            .rig2
+            .get(1)
+            .expect("rig 2 configuration")
             .as_ref()
             .map(open)
             .transpose()

--- a/catserver/src/hamlib_radio_tests.rs
+++ b/catserver/src/hamlib_radio_tests.rs
@@ -3,26 +3,27 @@ use std::collections::BTreeMap;
 use crate::{
     freq::Freq,
     hamlib_radio::HamlibRadio,
-    radio_config::{HamlibConfig, HamlibRigConfig},
+    radio_config::HamlibRigConfig,
     rig::{Mode, Radio, Slot},
 };
 
-fn config(rig2: bool) -> HamlibConfig {
-    HamlibConfig {
-        rig1: HamlibRigConfig {
+fn config(rig2: bool) -> (HamlibRigConfig, Option<HamlibRigConfig>) {
+    (
+        HamlibRigConfig {
             model_id: hamlib::RigModelId::DUMMY.to_string(),
             token_values: BTreeMap::new(),
         },
-        rig2: rig2.then(|| HamlibRigConfig {
+        rig2.then(|| HamlibRigConfig {
             model_id: hamlib::RigModelId::DUMMY.to_string(),
             token_values: BTreeMap::new(),
         }),
-    }
+    )
 }
 
 #[test]
 fn dummy_rigs_select_vfos_and_map_modes() {
-    let mut radio = HamlibRadio::new(config(true));
+    let (rig1, rig2) = config(true);
+    let mut radio = HamlibRadio::new(rig1, rig2);
     radio.init().unwrap();
     radio.set_frequency(Slot::A, Freq::from_u32_hz(7_100_000));
     radio.set_mode(Mode::CW);
@@ -39,7 +40,8 @@ fn dummy_rigs_select_vfos_and_map_modes() {
 
 #[test]
 fn absent_second_rig_is_not_selected() {
-    let mut radio = HamlibRadio::new(config(false));
+    let (rig1, rig2) = config(false);
+    let mut radio = HamlibRadio::new(rig1, rig2);
     radio.init().unwrap();
     radio.set_rig(2);
     assert_eq!(radio.get_status().current_rig, 1);
@@ -47,9 +49,9 @@ fn absent_second_rig_is_not_selected() {
 
 #[test]
 fn invalid_second_rig_reports_its_slot_and_can_retry() {
-    let mut config = config(true);
-    config.rig2.as_mut().unwrap().model_id = "999999".into();
-    let mut radio = HamlibRadio::new(config);
+    let (rig1, mut rig2) = config(true);
+    rig2.as_mut().unwrap().model_id = "999999".into();
+    let mut radio = HamlibRadio::new(rig1, rig2);
     assert!(matches!(
         radio.init(),
         Err(crate::rig::RadioInitError::Hamlib { rig: 2, .. })

--- a/catserver/src/radio_config.rs
+++ b/catserver/src/radio_config.rs
@@ -10,11 +10,14 @@ use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
 const CONFIG_FILE: &str = "radio.json";
-const SCHEMA_VERSION: u8 = 1;
+const SCHEMA_VERSION: u8 = 2;
+pub const DEFAULT_RIGCTLD_HOST: &str = "127.0.0.1";
+pub const DEFAULT_RIGCTLD_PORT: u16 = 4532;
 type IoFailure = (PathBuf, std::io::Error);
 type RenameFailure = (PathBuf, PathBuf, std::io::Error);
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum RadioBackendKind {
     Omnirig,
     Rigctld,
@@ -34,15 +37,27 @@ pub struct HamlibRigConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
-pub struct HamlibConfig {
-    pub rig1: HamlibRigConfig,
-    pub rig2: Option<HamlibRigConfig>,
+pub struct RigctldConfig {
+    #[serde(default = "default_rigctld_host")]
+    pub host: String,
+    #[serde(default = "default_rigctld_port")]
+    pub port: u16,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct RadioConfig {
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+pub struct RadioRigConfig {
     pub backend: RadioBackendKind,
-    pub hamlib: Option<HamlibConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hamlib: Option<HamlibRigConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rigctld: Option<RigctldConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+pub struct RadioConfig {
+    pub rig1: RadioRigConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rig2: Option<RadioRigConfig>,
 }
 
 #[derive(Debug)]
@@ -55,10 +70,12 @@ pub enum RadioConfigError {
     UnsupportedVersion(u8),
     UnknownBackend(String),
     PlatformUnsupportedBackend(RadioBackendKind),
-    MissingHamlibConfiguration,
-    UnexpectedHamlibConfiguration,
+    MissingBackendConfiguration(RadioBackendKind),
+    UnexpectedBackendConfiguration,
     InvalidModelId(String),
     InvalidToken(String),
+    InvalidRigctldHost(String),
+    InvalidRigctldPort,
     WriteTemporary(IoFailure),
     Rename(RenameFailure),
 }
@@ -74,37 +91,34 @@ impl std::error::Error for RadioConfigError {}
 #[derive(Deserialize)]
 struct ConfigHeader {
     version: u8,
-    backend: String,
 }
 
 #[derive(Deserialize)]
-#[serde(tag = "backend", rename_all = "snake_case")]
-enum PersistedRadioConfig {
-    Omnirig,
-    Rigctld,
-    Hamlib { hamlib: HamlibConfig },
+pub(crate) struct LegacyRadioConfig {
+    pub(crate) backend: String,
+    #[serde(default)]
+    pub(crate) hamlib: Option<LegacyHamlibConfig>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct LegacyHamlibConfig {
+    pub(crate) rig1: HamlibRigConfig,
+    #[serde(default)]
+    pub(crate) rig2: Option<HamlibRigConfig>,
 }
 
 #[derive(Serialize)]
 struct PersistedConfig<'a> {
     version: u8,
     #[serde(flatten)]
-    config: PersistedRadioConfigRef<'a>,
-}
-
-#[derive(Serialize)]
-#[serde(tag = "backend", rename_all = "snake_case")]
-enum PersistedRadioConfigRef<'a> {
-    Omnirig,
-    Rigctld,
-    Hamlib { hamlib: &'a HamlibConfig },
+    config: &'a RadioConfig,
 }
 
 impl RadioConfig {
     pub fn platform_default() -> Self {
         Self {
-            backend: RadioBackendKind::platform_default(),
-            hamlib: None,
+            rig1: RadioRigConfig::platform_default(),
+            rig2: None,
         }
     }
 
@@ -120,22 +134,17 @@ impl RadioConfig {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 return Ok(Self::platform_default());
             }
-            Err(source) => {
-                return Err(RadioConfigError::Read((path.to_path_buf(), source)));
-            }
+            Err(source) => return Err(RadioConfigError::Read((path.to_path_buf(), source))),
         };
         let header: ConfigHeader =
             serde_json::from_str(&contents).map_err(RadioConfigError::Json)?;
-        if header.version != SCHEMA_VERSION {
-            return Err(RadioConfigError::UnsupportedVersion(header.version));
-        }
-        let persisted = match header.backend.as_str() {
-            "omnirig" | "rigctld" | "hamlib" => {
-                serde_json::from_str(&contents).map_err(RadioConfigError::Json)?
-            }
-            _ => return Err(RadioConfigError::UnknownBackend(header.backend)),
+        let config = match header.version {
+            1 => Self::from_legacy(
+                serde_json::from_str(&contents).map_err(RadioConfigError::Json)?,
+            )?,
+            SCHEMA_VERSION => serde_json::from_str(&contents).map_err(RadioConfigError::Json)?,
+            version => return Err(RadioConfigError::UnsupportedVersion(version)),
         };
-        let config = Self::from_persisted(persisted);
         config.validate()?;
         Ok(config)
     }
@@ -160,7 +169,7 @@ impl RadioConfig {
         })?;
         let temporary_path = path.with_extension("json.tmp");
         let serialized =
-            serde_json::to_vec_pretty(&self.persisted()?).map_err(RadioConfigError::Serialize)?;
+            serde_json::to_vec_pretty(&self.persisted()).map_err(RadioConfigError::Serialize)?;
         let write_result = File::create(&temporary_path)
             .and_then(|mut temporary| {
                 temporary.write_all(&serialized)?;
@@ -173,11 +182,7 @@ impl RadioConfig {
         }
         if let Err(source) = rename(&temporary_path, path) {
             let _ = fs::remove_file(&temporary_path);
-            return Err(RadioConfigError::Rename((
-                temporary_path,
-                path.to_path_buf(),
-                source,
-            )));
+            return Err(RadioConfigError::Rename((temporary_path, path.to_path_buf(), source)));
         }
         Ok(())
     }
@@ -186,57 +191,46 @@ impl RadioConfig {
         if dummy {
             ActiveRadioBackend::Dummy
         } else {
-            ActiveRadioBackend::Configured(self.backend)
+            ActiveRadioBackend::Configured(self.rig1.backend)
         }
     }
 
-    fn from_persisted(config: PersistedRadioConfig) -> Self {
-        match config {
-            PersistedRadioConfig::Omnirig => Self {
-                backend: RadioBackendKind::Omnirig,
-                hamlib: None,
-            },
-            PersistedRadioConfig::Rigctld => Self {
-                backend: RadioBackendKind::Rigctld,
-                hamlib: None,
-            },
-            PersistedRadioConfig::Hamlib { hamlib } => Self {
-                backend: RadioBackendKind::Hamlib,
-                hamlib: Some(hamlib),
-            },
-        }
-    }
-
-    fn persisted(&self) -> Result<PersistedConfig<'_>, RadioConfigError> {
-        let config = match (&self.backend, &self.hamlib) {
-            (RadioBackendKind::Omnirig, None) => PersistedRadioConfigRef::Omnirig,
-            (RadioBackendKind::Rigctld, None) => PersistedRadioConfigRef::Rigctld,
-            (RadioBackendKind::Hamlib, Some(hamlib)) => PersistedRadioConfigRef::Hamlib { hamlib },
-            (RadioBackendKind::Omnirig, Some(_)) | (RadioBackendKind::Rigctld, Some(_)) => {
-                return Err(RadioConfigError::UnexpectedHamlibConfiguration);
-            }
-            (RadioBackendKind::Hamlib, None) => {
-                return Err(RadioConfigError::MissingHamlibConfiguration);
-            }
+    pub(crate) fn from_legacy(config: LegacyRadioConfig) -> Result<Self, RadioConfigError> {
+        let backend = match config.backend.as_str() {
+            "omnirig" => RadioBackendKind::Omnirig,
+            "rigctld" => RadioBackendKind::Rigctld,
+            "hamlib" => RadioBackendKind::Hamlib,
+            _ => return Err(RadioConfigError::UnknownBackend(config.backend)),
         };
-        Ok(PersistedConfig {
+        let (rig1, rig2) = match backend {
+            RadioBackendKind::Hamlib => {
+                let hamlib = config
+                    .hamlib
+                    .ok_or(RadioConfigError::MissingBackendConfiguration(backend))?;
+                (
+                    RadioRigConfig::hamlib(hamlib.rig1),
+                    hamlib.rig2.map(RadioRigConfig::hamlib),
+                )
+            }
+            RadioBackendKind::Rigctld => (RadioRigConfig::rigctld_default(), None),
+            RadioBackendKind::Omnirig => (RadioRigConfig::omnirig(), None),
+        };
+        Ok(Self { rig1, rig2 })
+    }
+
+    fn persisted(&self) -> PersistedConfig<'_> {
+        PersistedConfig {
             version: SCHEMA_VERSION,
-            config,
-        })
+            config: self,
+        }
     }
 
     pub(crate) fn validate(&self) -> Result<(), RadioConfigError> {
-        if !self.backend.is_supported_on_platform() {
-            return Err(RadioConfigError::PlatformUnsupportedBackend(self.backend));
+        self.rig1.validate()?;
+        if let Some(rig2) = &self.rig2 {
+            rig2.validate()?;
         }
-        match (&self.backend, &self.hamlib) {
-            (RadioBackendKind::Hamlib, Some(hamlib)) => hamlib.validate(),
-            (RadioBackendKind::Hamlib, None) => Err(RadioConfigError::MissingHamlibConfiguration),
-            (RadioBackendKind::Omnirig, None) | (RadioBackendKind::Rigctld, None) => Ok(()),
-            (RadioBackendKind::Omnirig, Some(_)) | (RadioBackendKind::Rigctld, Some(_)) => {
-                Err(RadioConfigError::UnexpectedHamlibConfiguration)
-            }
-        }
+        Ok(())
     }
 }
 
@@ -261,11 +255,69 @@ impl RadioBackendKind {
     }
 }
 
-impl HamlibConfig {
+impl RadioRigConfig {
+    pub fn hamlib(hamlib: HamlibRigConfig) -> Self {
+        Self {
+            backend: RadioBackendKind::Hamlib,
+            hamlib: Some(hamlib),
+            rigctld: None,
+        }
+    }
+
+    pub fn rigctld_default() -> Self {
+        Self {
+            backend: RadioBackendKind::Rigctld,
+            hamlib: None,
+            rigctld: Some(RigctldConfig::default()),
+        }
+    }
+
+    pub fn omnirig() -> Self {
+        Self {
+            backend: RadioBackendKind::Omnirig,
+            hamlib: None,
+            rigctld: None,
+        }
+    }
+
+    fn platform_default() -> Self {
+        match RadioBackendKind::platform_default() {
+            RadioBackendKind::Omnirig => Self::omnirig(),
+            RadioBackendKind::Rigctld => Self::rigctld_default(),
+            RadioBackendKind::Hamlib => unreachable!(),
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), RadioConfigError> {
+        if !self.backend.is_supported_on_platform() {
+            return Err(RadioConfigError::PlatformUnsupportedBackend(self.backend));
+        }
+        match (&self.backend, &self.hamlib, &self.rigctld) {
+            (RadioBackendKind::Hamlib, Some(hamlib), None) => hamlib.validate(),
+            (RadioBackendKind::Rigctld, None, Some(rigctld)) => rigctld.validate(),
+            (RadioBackendKind::Omnirig, None, None) => Ok(()),
+            (backend, None, _) => Err(RadioConfigError::MissingBackendConfiguration(*backend)),
+            _ => Err(RadioConfigError::UnexpectedBackendConfiguration),
+        }
+    }
+}
+
+impl Default for RigctldConfig {
+    fn default() -> Self {
+        Self {
+            host: default_rigctld_host(),
+            port: default_rigctld_port(),
+        }
+    }
+}
+
+impl RigctldConfig {
     fn validate(&self) -> Result<(), RadioConfigError> {
-        self.rig1.validate()?;
-        if let Some(rig2) = &self.rig2 {
-            rig2.validate()?;
+        if self.host.trim().is_empty() || self.host.chars().any(char::is_whitespace) {
+            return Err(RadioConfigError::InvalidRigctldHost(self.host.clone()));
+        }
+        if self.port == 0 {
+            return Err(RadioConfigError::InvalidRigctldPort);
         }
         Ok(())
     }
@@ -290,4 +342,12 @@ fn is_descriptor_token(token: &str) -> bool {
     let mut characters = token.chars();
     matches!(characters.next(), Some(character) if character.is_ascii_alphabetic())
         && characters.all(|character| character.is_ascii_alphanumeric() || character == '_')
+}
+
+fn default_rigctld_host() -> String {
+    DEFAULT_RIGCTLD_HOST.into()
+}
+
+const fn default_rigctld_port() -> u16 {
+    DEFAULT_RIGCTLD_PORT
 }

--- a/catserver/src/radio_config.rs
+++ b/catserver/src/radio_config.rs
@@ -139,9 +139,9 @@ impl RadioConfig {
         let header: ConfigHeader =
             serde_json::from_str(&contents).map_err(RadioConfigError::Json)?;
         let config = match header.version {
-            1 => Self::from_legacy(
-                serde_json::from_str(&contents).map_err(RadioConfigError::Json)?,
-            )?,
+            1 => {
+                Self::from_legacy(serde_json::from_str(&contents).map_err(RadioConfigError::Json)?)?
+            }
             SCHEMA_VERSION => serde_json::from_str(&contents).map_err(RadioConfigError::Json)?,
             version => return Err(RadioConfigError::UnsupportedVersion(version)),
         };
@@ -182,7 +182,11 @@ impl RadioConfig {
         }
         if let Err(source) = rename(&temporary_path, path) {
             let _ = fs::remove_file(&temporary_path);
-            return Err(RadioConfigError::Rename((temporary_path, path.to_path_buf(), source)));
+            return Err(RadioConfigError::Rename((
+                temporary_path,
+                path.to_path_buf(),
+                source,
+            )));
         }
         Ok(())
     }

--- a/catserver/src/radio_config_tests.rs
+++ b/catserver/src/radio_config_tests.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use crate::radio_config::{
-    ActiveRadioBackend, HamlibConfig, HamlibRigConfig, RadioBackendKind, RadioConfig,
-    RadioConfigError,
+    ActiveRadioBackend, HamlibRigConfig, RadioBackendKind, RadioConfig, RadioConfigError,
+    RadioRigConfig, RigctldConfig, DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_PORT,
 };
 
 struct TestDir(PathBuf);
@@ -34,19 +34,17 @@ impl Drop for TestDir {
     }
 }
 
+fn hamlib(model_id: &str) -> RadioRigConfig {
+    RadioRigConfig::hamlib(HamlibRigConfig {
+        model_id: model_id.into(),
+        token_values: BTreeMap::from([("rig_pathname".into(), "/dev/ttyUSB0".into())]),
+    })
+}
+
 fn two_rig_config() -> RadioConfig {
     RadioConfig {
-        backend: RadioBackendKind::Hamlib,
-        hamlib: Some(HamlibConfig {
-            rig1: HamlibRigConfig {
-                model_id: "1".into(),
-                token_values: BTreeMap::from([("rig_pathname".into(), "/dev/ttyUSB0".into())]),
-            },
-            rig2: Some(HamlibRigConfig {
-                model_id: "2".into(),
-                token_values: BTreeMap::from([("rig_pathname".into(), "/dev/ttyUSB1".into())]),
-            }),
-        }),
+        rig1: hamlib("1"),
+        rig2: Some(hamlib("2")),
     }
 }
 
@@ -60,95 +58,95 @@ fn returns_platform_default_when_config_file_is_missing() {
 }
 
 #[test]
-fn round_trips_one_and_two_hamlib_rigs() {
+fn round_trips_independently_configured_rigs() {
     let directory = TestDir::new();
-    let one_rig = RadioConfig {
-        backend: RadioBackendKind::Hamlib,
-        hamlib: Some(HamlibConfig {
-            rig1: HamlibRigConfig {
-                model_id: "1".into(),
-                token_values: BTreeMap::new(),
-            },
-            rig2: None,
-        }),
+    let config = RadioConfig {
+        rig1: RadioConfig::platform_default().rig1,
+        rig2: Some(hamlib("2")),
     };
 
-    one_rig.save_to_path(&directory.file()).unwrap();
-    assert_eq!(
-        RadioConfig::load_from_path(&directory.file()).unwrap(),
-        one_rig
-    );
+    config.save_to_path(&directory.file()).unwrap();
 
-    let two_rigs = two_rig_config();
-    two_rigs.save_to_path(&directory.file()).unwrap();
-    assert_eq!(
-        RadioConfig::load_from_path(&directory.file()).unwrap(),
-        two_rigs
-    );
+    assert_eq!(RadioConfig::load_from_path(&directory.file()).unwrap(), config);
+}
+
+#[test]
+fn migrates_legacy_global_backend_configuration() {
+    let directory = TestDir::new();
+    fs::write(
+        directory.file(),
+        r#"{"version":1,"backend":"hamlib","hamlib":{"rig1":{"model_id":"1","token_values":{}},"rig2":{"model_id":"2","token_values":{}}}}"#,
+    )
+    .unwrap();
+
+    assert_eq!(RadioConfig::load_from_path(&directory.file()).unwrap(), RadioConfig {
+        rig1: RadioRigConfig::hamlib(HamlibRigConfig {
+            model_id: "1".into(),
+            token_values: BTreeMap::new(),
+        }),
+        rig2: Some(RadioRigConfig::hamlib(HamlibRigConfig {
+            model_id: "2".into(),
+            token_values: BTreeMap::new(),
+        })),
+    });
+}
+
+#[test]
+fn defaults_rigctld_endpoint_when_omitted() {
+    let config: RadioRigConfig = serde_json::from_str(r#"{"backend":"rigctld","rigctld":{}}"#).unwrap();
+
+    assert_eq!(config.rigctld, Some(RigctldConfig {
+        host: DEFAULT_RIGCTLD_HOST.into(),
+        port: DEFAULT_RIGCTLD_PORT,
+    }));
+}
+
+#[cfg(not(windows))]
+#[test]
+fn rejects_invalid_rigctld_endpoints() {
+    let config = RadioConfig {
+        rig1: RadioRigConfig {
+            backend: RadioBackendKind::Rigctld,
+            hamlib: None,
+            rigctld: Some(RigctldConfig {
+                host: " ".into(),
+                port: 0,
+            }),
+        },
+        rig2: None,
+    };
+
+    assert!(matches!(config.validate(), Err(RadioConfigError::InvalidRigctldHost(_))));
+
+    let config = RadioConfig {
+        rig1: RadioRigConfig {
+            backend: RadioBackendKind::Rigctld,
+            hamlib: None,
+            rigctld: Some(RigctldConfig {
+                host: "127.0.0.1".into(),
+                port: 0,
+            }),
+        },
+        rig2: None,
+    };
+
+    assert!(matches!(config.validate(), Err(RadioConfigError::InvalidRigctldPort)));
 }
 
 #[test]
 fn rejects_unknown_schema_version_and_backend() {
     let directory = TestDir::new();
 
-    fs::write(directory.file(), r#"{"version":2,"backend":"rigctld"}"#).unwrap();
+    fs::write(directory.file(), r#"{"version":3,"rig1":{"backend":"rigctld"}}"#).unwrap();
     assert!(matches!(
         RadioConfig::load_from_path(&directory.file()),
-        Err(RadioConfigError::UnsupportedVersion(2))
+        Err(RadioConfigError::UnsupportedVersion(3))
     ));
 
     fs::write(directory.file(), r#"{"version":1,"backend":"unknown"}"#).unwrap();
     assert!(matches!(
         RadioConfig::load_from_path(&directory.file()),
         Err(RadioConfigError::UnknownBackend(_))
-    ));
-}
-
-#[test]
-fn rejects_malformed_json_and_invalid_hamlib_shapes() {
-    let directory = TestDir::new();
-
-    fs::write(directory.file(), "{").unwrap();
-    assert!(matches!(
-        RadioConfig::load_from_path(&directory.file()),
-        Err(RadioConfigError::Json(_))
-    ));
-
-    fs::write(
-        directory.file(),
-        r#"{"version":1,"backend":"hamlib","hamlib":{"rig1":{"model_id":"zero","token_values":{"":"9600"}}}}"#,
-    )
-    .unwrap();
-    assert!(matches!(
-        RadioConfig::load_from_path(&directory.file()),
-        Err(RadioConfigError::InvalidModelId(_))
-    ));
-
-    fs::write(
-        directory.file(),
-        r#"{"version":1,"backend":"hamlib","hamlib":{"rig1":{"model_id":"1","token_values":{"":"9600"}}}}"#,
-    )
-    .unwrap();
-    assert!(matches!(
-        RadioConfig::load_from_path(&directory.file()),
-        Err(RadioConfigError::InvalidToken(_))
-    ));
-}
-
-#[test]
-fn rejects_backend_not_supported_by_this_platform() {
-    let directory = TestDir::new();
-    let backend = if cfg!(windows) { "rigctld" } else { "omnirig" };
-
-    fs::write(
-        directory.file(),
-        format!(r#"{{"version":1,"backend":"{backend}"}}"#),
-    )
-    .unwrap();
-
-    assert!(matches!(
-        RadioConfig::load_from_path(&directory.file()),
-        Err(RadioConfigError::PlatformUnsupportedBackend(_))
     ));
 }
 
@@ -193,48 +191,7 @@ fn dummy_override_is_explicit_and_never_persisted() {
     assert_eq!(config.effective_backend(true), ActiveRadioBackend::Dummy);
     assert_eq!(
         config.effective_backend(false),
-        ActiveRadioBackend::Configured(config.backend)
+        ActiveRadioBackend::Configured(config.rig1.backend)
     );
     assert!(!persisted.contains("dummy"));
-}
-
-#[test]
-fn prints_canonical_one_and_two_rig_configurations_for_manual_qa() {
-    let directory = TestDir::new();
-    let one_rig = RadioConfig {
-        backend: RadioBackendKind::Hamlib,
-        hamlib: Some(HamlibConfig {
-            rig1: HamlibRigConfig {
-                model_id: "1".into(),
-                token_values: BTreeMap::new(),
-            },
-            rig2: None,
-        }),
-    };
-
-    one_rig.save_to_path(&directory.file()).unwrap();
-    println!("one-rig={}", fs::read_to_string(directory.file()).unwrap());
-    assert_eq!(
-        RadioConfig::load_from_path(&directory.file()).unwrap(),
-        one_rig
-    );
-
-    let two_rigs = two_rig_config();
-    two_rigs.save_to_path(&directory.file()).unwrap();
-    println!("two-rig={}", fs::read_to_string(directory.file()).unwrap());
-    assert_eq!(
-        RadioConfig::load_from_path(&directory.file()).unwrap(),
-        two_rigs
-    );
-
-    let malformed_path = directory.0.join("malformed-radio.json");
-    fs::write(&malformed_path, "{").unwrap();
-    println!(
-        "malformed-error={}",
-        RadioConfig::load_from_path(&malformed_path).unwrap_err()
-    );
-    assert_eq!(
-        RadioConfig::load_from_path(&directory.file()).unwrap(),
-        two_rigs
-    );
 }

--- a/catserver/src/radio_config_tests.rs
+++ b/catserver/src/radio_config_tests.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use crate::radio_config::{
-    ActiveRadioBackend, HamlibRigConfig, RadioBackendKind, RadioConfig, RadioConfigError,
-    RadioRigConfig, RigctldConfig, DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_PORT,
+    ActiveRadioBackend, DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_PORT, HamlibRigConfig,
+    RadioBackendKind, RadioConfig, RadioConfigError, RadioRigConfig, RigctldConfig,
 };
 
 struct TestDir(PathBuf);
@@ -67,7 +67,10 @@ fn round_trips_independently_configured_rigs() {
 
     config.save_to_path(&directory.file()).unwrap();
 
-    assert_eq!(RadioConfig::load_from_path(&directory.file()).unwrap(), config);
+    assert_eq!(
+        RadioConfig::load_from_path(&directory.file()).unwrap(),
+        config
+    );
 }
 
 #[test]
@@ -79,26 +82,33 @@ fn migrates_legacy_global_backend_configuration() {
     )
     .unwrap();
 
-    assert_eq!(RadioConfig::load_from_path(&directory.file()).unwrap(), RadioConfig {
-        rig1: RadioRigConfig::hamlib(HamlibRigConfig {
-            model_id: "1".into(),
-            token_values: BTreeMap::new(),
-        }),
-        rig2: Some(RadioRigConfig::hamlib(HamlibRigConfig {
-            model_id: "2".into(),
-            token_values: BTreeMap::new(),
-        })),
-    });
+    assert_eq!(
+        RadioConfig::load_from_path(&directory.file()).unwrap(),
+        RadioConfig {
+            rig1: RadioRigConfig::hamlib(HamlibRigConfig {
+                model_id: "1".into(),
+                token_values: BTreeMap::new(),
+            }),
+            rig2: Some(RadioRigConfig::hamlib(HamlibRigConfig {
+                model_id: "2".into(),
+                token_values: BTreeMap::new(),
+            })),
+        }
+    );
 }
 
 #[test]
 fn defaults_rigctld_endpoint_when_omitted() {
-    let config: RadioRigConfig = serde_json::from_str(r#"{"backend":"rigctld","rigctld":{}}"#).unwrap();
+    let config: RadioRigConfig =
+        serde_json::from_str(r#"{"backend":"rigctld","rigctld":{}}"#).unwrap();
 
-    assert_eq!(config.rigctld, Some(RigctldConfig {
-        host: DEFAULT_RIGCTLD_HOST.into(),
-        port: DEFAULT_RIGCTLD_PORT,
-    }));
+    assert_eq!(
+        config.rigctld,
+        Some(RigctldConfig {
+            host: DEFAULT_RIGCTLD_HOST.into(),
+            port: DEFAULT_RIGCTLD_PORT,
+        })
+    );
 }
 
 #[cfg(not(windows))]
@@ -116,7 +126,10 @@ fn rejects_invalid_rigctld_endpoints() {
         rig2: None,
     };
 
-    assert!(matches!(config.validate(), Err(RadioConfigError::InvalidRigctldHost(_))));
+    assert!(matches!(
+        config.validate(),
+        Err(RadioConfigError::InvalidRigctldHost(_))
+    ));
 
     let config = RadioConfig {
         rig1: RadioRigConfig {
@@ -130,14 +143,21 @@ fn rejects_invalid_rigctld_endpoints() {
         rig2: None,
     };
 
-    assert!(matches!(config.validate(), Err(RadioConfigError::InvalidRigctldPort)));
+    assert!(matches!(
+        config.validate(),
+        Err(RadioConfigError::InvalidRigctldPort)
+    ));
 }
 
 #[test]
 fn rejects_unknown_schema_version_and_backend() {
     let directory = TestDir::new();
 
-    fs::write(directory.file(), r#"{"version":3,"rig1":{"backend":"rigctld"}}"#).unwrap();
+    fs::write(
+        directory.file(),
+        r#"{"version":3,"rig1":{"backend":"rigctld"}}"#,
+    )
+    .unwrap();
     assert!(matches!(
         RadioConfig::load_from_path(&directory.file()),
         Err(RadioConfigError::UnsupportedVersion(3))

--- a/catserver/src/radio_factory.rs
+++ b/catserver/src/radio_factory.rs
@@ -1,9 +1,10 @@
 use crate::{
     dummy::DummyRadio,
+    freq::Freq,
     hamlib_radio::HamlibRadio,
     radio_actor::RadioFactory,
-    radio_config::{ActiveRadioBackend, RadioBackendKind, RadioConfig},
-    rig::{Radio, UnavailableRadio},
+    radio_config::{ActiveRadioBackend, RadioBackendKind, RadioConfig, RadioRigConfig},
+    rig::{Mode, Radio, RadioInitError, Slot, Status, UnavailableRadio},
 };
 
 #[cfg(windows)]
@@ -24,27 +25,196 @@ fn build(
     selected: &ActiveRadioBackend,
     rigctld_endpoint: &(String, u16),
 ) -> Box<dyn Radio> {
-    #[cfg(windows)]
     let _ = rigctld_endpoint;
     match selected {
         ActiveRadioBackend::Dummy => Box::new(DummyRadio::new()),
-        ActiveRadioBackend::Configured(RadioBackendKind::Hamlib) => config
+        ActiveRadioBackend::Configured(_) => Box::new(CompositeRadio::new(
+            radio(&config.rig1, 1),
+            config.rig2.as_ref().map(|rig| radio(rig, 2)),
+        )),
+    }
+}
+
+fn radio(config: &RadioRigConfig, rig: u8) -> FixedRigRadio {
+    let radio: Box<dyn Radio> = match config.backend {
+        RadioBackendKind::Hamlib => config
             .hamlib
             .clone()
-            .map(HamlibRadio::new)
-            .map(|radio| Box::new(radio) as Box<dyn Radio>)
+            .map(|hamlib| Box::new(HamlibRadio::new(hamlib, None)) as Box<dyn Radio>)
             .unwrap_or_else(|| Box::new(UnavailableRadio::new("hamlib"))),
-        #[cfg(windows)]
-        ActiveRadioBackend::Configured(RadioBackendKind::Omnirig) => Box::new(OmnirigRadio::new()),
         #[cfg(not(windows))]
-        ActiveRadioBackend::Configured(RadioBackendKind::Rigctld) => Box::new(RigctldRadio::new(
-            rigctld_endpoint.0.clone(),
-            rigctld_endpoint.1,
-        )),
-        ActiveRadioBackend::Configured(backend) => Box::new(UnavailableRadio::new(match backend {
-            RadioBackendKind::Omnirig => "omnirig",
-            RadioBackendKind::Rigctld => "rigctld",
-            RadioBackendKind::Hamlib => unreachable!(),
-        })),
+        RadioBackendKind::Rigctld => config
+            .rigctld
+            .as_ref()
+            .map(|rigctld| {
+                Box::new(RigctldRadio::new(rigctld.host.clone(), rigctld.port)) as Box<dyn Radio>
+            })
+            .unwrap_or_else(|| Box::new(UnavailableRadio::new("rigctld"))),
+        #[cfg(windows)]
+        RadioBackendKind::Omnirig => Box::new(OmnirigRadio::new()),
+        #[cfg(not(windows))]
+        RadioBackendKind::Omnirig => Box::new(UnavailableRadio::new("omnirig")),
+        #[cfg(windows)]
+        RadioBackendKind::Rigctld => Box::new(UnavailableRadio::new("rigctld")),
+    };
+    FixedRigRadio { rig, radio }
+}
+
+struct CompositeRadio {
+    rigs: [Option<FixedRigRadio>; 2],
+    current_rig: u8,
+}
+
+impl CompositeRadio {
+    fn new(rig1: FixedRigRadio, rig2: Option<FixedRigRadio>) -> Self {
+        Self {
+            rigs: [Some(rig1), rig2],
+            current_rig: 1,
+        }
+    }
+
+    fn current(&mut self) -> Option<&mut FixedRigRadio> {
+        self.rigs
+            .get_mut(usize::from(self.current_rig - 1))?
+            .as_mut()
+    }
+}
+
+impl Radio for CompositeRadio {
+    fn init(&mut self) -> Result<(), RadioInitError> {
+        for rig in self.rigs.iter_mut().flatten() {
+            rig.init()?;
+        }
+        Ok(())
+    }
+
+    fn set_mode(&mut self, mode: Mode) {
+        if let Some(rig) = self.current() {
+            rig.set_mode(mode);
+        }
+    }
+
+    fn set_rig(&mut self, rig: u8) {
+        if (1..=2).contains(&rig) && self.rigs[usize::from(rig - 1)].is_some() {
+            self.current_rig = rig;
+        }
+    }
+
+    fn set_frequency(&mut self, slot: Slot, freq: Freq) {
+        if let Some(rig) = self.current() {
+            rig.set_frequency(slot, freq);
+        }
+    }
+
+    fn get_status(&mut self) -> Status {
+        let current_rig = self.current_rig;
+        self.current()
+            .map(Radio::get_status)
+            .unwrap_or_else(|| Status::disconnected(current_rig))
+    }
+}
+
+struct FixedRigRadio {
+    rig: u8,
+    radio: Box<dyn Radio>,
+}
+
+impl Radio for FixedRigRadio {
+    fn init(&mut self) -> Result<(), RadioInitError> {
+        self.radio.init().map_err(|error| match error {
+            RadioInitError::Hamlib { error, .. } => RadioInitError::Hamlib {
+                rig: self.rig,
+                error,
+            },
+            error => error,
+        })
+    }
+
+    fn set_mode(&mut self, mode: Mode) {
+        self.radio.set_rig(self.rig);
+        self.radio.set_mode(mode);
+    }
+
+    fn set_rig(&mut self, _: u8) {}
+
+    fn set_frequency(&mut self, slot: Slot, freq: Freq) {
+        self.radio.set_rig(self.rig);
+        self.radio.set_frequency(slot, freq);
+    }
+
+    fn get_status(&mut self) -> Status {
+        self.radio.set_rig(self.rig);
+        let mut status = self.radio.get_status();
+        status.current_rig = self.rig;
+        status
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::{CompositeRadio, FixedRigRadio};
+    use crate::{
+        freq::Freq,
+        rig::{Mode, Radio, RadioInitError, Slot, Status},
+    };
+
+    struct RecordingRadio {
+        events: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl Radio for RecordingRadio {
+        fn init(&mut self) -> Result<(), RadioInitError> {
+            Ok(())
+        }
+
+        fn set_mode(&mut self, mode: Mode) {
+            self.events.lock().unwrap().push(format!("mode:{mode:?}"));
+        }
+
+        fn set_rig(&mut self, rig: u8) {
+            self.events.lock().unwrap().push(format!("rig:{rig}"));
+        }
+
+        fn set_frequency(&mut self, _: Slot, _: Freq) {}
+
+        fn get_status(&mut self) -> Status {
+            Status::disconnected(0)
+        }
+    }
+
+    #[test]
+    fn routes_operations_to_the_selected_rig_backend() {
+        let rig1_events = Arc::new(Mutex::new(Vec::new()));
+        let rig2_events = Arc::new(Mutex::new(Vec::new()));
+        let mut radio = CompositeRadio::new(
+            FixedRigRadio {
+                rig: 1,
+                radio: Box::new(RecordingRadio {
+                    events: Arc::clone(&rig1_events),
+                }),
+            },
+            Some(FixedRigRadio {
+                rig: 2,
+                radio: Box::new(RecordingRadio {
+                    events: Arc::clone(&rig2_events),
+                }),
+            }),
+        );
+
+        radio.set_mode(Mode::USB);
+        radio.set_rig(2);
+        radio.set_mode(Mode::CW);
+
+        assert_eq!(
+            *rig1_events.lock().unwrap(),
+            vec!["rig:1".to_owned(), "mode:USB".to_owned()]
+        );
+        assert_eq!(
+            *rig2_events.lock().unwrap(),
+            vec!["rig:2".to_owned(), "mode:CW".to_owned()]
+        );
+        assert_eq!(radio.get_status().current_rig, 2);
     }
 }

--- a/catserver/src/radio_manager_tests.rs
+++ b/catserver/src/radio_manager_tests.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     dummy::DummyRadio,
     radio_actor::Worker,
-    radio_config::{ActiveRadioBackend, RadioBackendKind, RadioConfig},
+    radio_config::{ActiveRadioBackend, RadioBackendKind, RadioConfig, RadioRigConfig},
     radio_manager::{ConnectionState, RadioManager},
     rig::{Mode, Radio, RadioInitError, Slot, Status},
 };
@@ -114,8 +114,12 @@ async fn failed_candidate_keeps_selected_backend_observable() {
 async fn invalid_candidate_preserves_active_radio() {
     let manager = manager().await;
     let invalid = RadioConfig {
-        backend: RadioBackendKind::Hamlib,
-        hamlib: None,
+        rig1: RadioRigConfig {
+            backend: RadioBackendKind::Hamlib,
+            hamlib: None,
+            rigctld: None,
+        },
+        rig2: None,
     };
     assert!(
         manager

--- a/catserver/src/server/radio.rs
+++ b/catserver/src/server/radio.rs
@@ -62,7 +62,10 @@ fn backend(backend: ActiveRadioBackend, config: &RadioConfig, current_rig: u8) -
         ActiveRadioBackend::Dummy => "dummy",
         ActiveRadioBackend::Configured(_) => {
             let backend = match current_rig {
-                2 => config.rig2.as_ref().map_or(config.rig1.backend, |rig| rig.backend),
+                2 => config
+                    .rig2
+                    .as_ref()
+                    .map_or(config.rig1.backend, |rig| rig.backend),
                 _ => config.rig1.backend,
             };
             backend_name(backend)

--- a/catserver/src/server/radio.rs
+++ b/catserver/src/server/radio.rs
@@ -3,7 +3,7 @@ use axum::extract::ws::Message;
 use serde::Serialize;
 
 use crate::{
-    radio_config::{ActiveRadioBackend, RadioBackendKind},
+    radio_config::{ActiveRadioBackend, RadioBackendKind, RadioConfig},
     radio_manager::{ConnectionState, RadioManager},
     rig::Status,
 };
@@ -54,15 +54,27 @@ pub(super) fn close_message() -> Result<Message> {
 
 fn status_data(data: &Status, radio: &RadioManager) -> serde_json::Value {
     let snapshot = radio.snapshot();
-    serde_json::json!({"freq": data.freq, "status": data.status, "mode": data.mode, "current_rig": data.current_rig, "backend": backend(snapshot.selected), "connection": connection(snapshot.connection), "error": snapshot.last_error.map(|error| error.to_string()), "features": ["radio_configuration"]})
+    serde_json::json!({"freq": data.freq, "status": data.status, "mode": data.mode, "current_rig": data.current_rig, "backend": backend(snapshot.selected, &snapshot.config, data.current_rig), "connection": connection(snapshot.connection), "error": snapshot.last_error.map(|error| error.to_string()), "features": ["radio_configuration"]})
 }
 
-fn backend(backend: ActiveRadioBackend) -> &'static str {
+fn backend(backend: ActiveRadioBackend, config: &RadioConfig, current_rig: u8) -> &'static str {
     match backend {
         ActiveRadioBackend::Dummy => "dummy",
-        ActiveRadioBackend::Configured(RadioBackendKind::Omnirig) => "omnirig",
-        ActiveRadioBackend::Configured(RadioBackendKind::Rigctld) => "rigctld",
-        ActiveRadioBackend::Configured(RadioBackendKind::Hamlib) => "hamlib",
+        ActiveRadioBackend::Configured(_) => {
+            let backend = match current_rig {
+                2 => config.rig2.as_ref().map_or(config.rig1.backend, |rig| rig.backend),
+                _ => config.rig1.backend,
+            };
+            backend_name(backend)
+        }
+    }
+}
+
+fn backend_name(backend: RadioBackendKind) -> &'static str {
+    match backend {
+        RadioBackendKind::Omnirig => "omnirig",
+        RadioBackendKind::Rigctld => "rigctld",
+        RadioBackendKind::Hamlib => "hamlib",
     }
 }
 

--- a/catserver/src/server/radio_actions.rs
+++ b/catserver/src/server/radio_actions.rs
@@ -43,7 +43,7 @@ enum ClientMessage {
     },
     GetRadioConfiguration,
     SetRadioConfiguration {
-        configuration: ConfigurationInput,
+        configuration: Box<ConfigurationInput>,
     },
     RetryRadio,
 }
@@ -119,7 +119,7 @@ async fn process(
         ),
         ClientMessage::SetRadioConfiguration { configuration } => (
             "configuration_result",
-            serde_json::to_value(match configuration.into_config() {
+            serde_json::to_value(match (*configuration).into_config() {
                 Ok(value) => service.set_configuration(value).await,
                 Err(error) => ConfigurationResult {
                     ok: false,

--- a/catserver/src/server/radio_actions.rs
+++ b/catserver/src/server/radio_actions.rs
@@ -2,10 +2,7 @@ use anyhow::Result;
 use axum::extract::ws::Message;
 use serde::Deserialize;
 
-use crate::{
-    radio_config::{RadioBackendKind, RadioConfig},
-    radio_manager::RadioManager,
-};
+use crate::{radio_config::RadioConfig, radio_manager::RadioManager};
 
 use super::{
     radio::message,
@@ -142,10 +139,5 @@ async fn control(message: ControlMessage, radio: &RadioManager) -> Result<Option
     Ok(None)
 }
 fn configuration_data(configuration: RadioConfig) -> serde_json::Value {
-    let backend = match configuration.backend {
-        RadioBackendKind::Omnirig => "omnirig",
-        RadioBackendKind::Rigctld => "rigctld",
-        RadioBackendKind::Hamlib => "hamlib",
-    };
-    serde_json::json!({"backend": backend, "hamlib": configuration.hamlib})
+    serde_json::to_value(configuration).expect("radio configuration is serializable")
 }

--- a/catserver/src/server/radio_actions_tests.rs
+++ b/catserver/src/server/radio_actions_tests.rs
@@ -3,12 +3,12 @@ use std::{collections::BTreeMap, sync::Arc};
 use super::{
     radio_actions::process_ws,
     radio_configuration::{
-        Capabilities, ConfigurationResult, FieldError, HamlibModel, ProductionRadioConfiguration,
-        RadioConfiguration, RadioConfigurationService,
+        Capabilities, ConfigurationInput, ConfigurationResult, FieldError, HamlibModel,
+        ProductionRadioConfiguration, RadioConfiguration, RadioConfigurationService,
     },
 };
 use crate::{
-    radio_config::{HamlibConfig, HamlibRigConfig, RadioBackendKind, RadioConfig},
+    radio_config::{HamlibRigConfig, RadioConfig, RadioRigConfig},
     radio_manager::RadioManager,
 };
 
@@ -82,18 +82,45 @@ async fn invalid_configuration_returns_a_field_error() {
     );
 }
 
+#[test]
+fn configuration_input_migrates_the_legacy_hamlib_shape() {
+    let input: ConfigurationInput = serde_json::from_str(
+        r#"{"backend":"hamlib","hamlib":{"rig1":{"model_id":"1","token_values":{}}}}"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        input.into_config().unwrap(),
+        RadioConfig {
+            rig1: RadioRigConfig::hamlib(HamlibRigConfig {
+                model_id: "1".into(),
+                token_values: BTreeMap::new(),
+            }),
+            rig2: None,
+        }
+    );
+}
+
+#[test]
+fn configuration_input_defaults_rigctld_endpoint_fields() {
+    let input: ConfigurationInput =
+        serde_json::from_str(r#"{"rig1":{"backend":"rigctld","rigctld":{}}}"#).unwrap();
+
+    let config = input.into_config().unwrap();
+    let rigctld = config.rig1.rigctld.unwrap();
+    assert_eq!(rigctld.host, "127.0.0.1");
+    assert_eq!(rigctld.port, 4532);
+}
+
 #[tokio::test]
 async fn production_configuration_rejects_unknown_descriptor_tokens() {
     let result = ProductionRadioConfiguration::new(radio())
         .set_configuration(RadioConfig {
-            backend: RadioBackendKind::Hamlib,
-            hamlib: Some(HamlibConfig {
-                rig1: HamlibRigConfig {
-                    model_id: "1".into(),
-                    token_values: BTreeMap::from([("unknown_token".into(), "value".into())]),
-                },
-                rig2: None,
+            rig1: RadioRigConfig::hamlib(HamlibRigConfig {
+                model_id: "1".into(),
+                token_values: BTreeMap::from([("unknown_token".into(), "value".into())]),
             }),
+            rig2: None,
         })
         .await;
     assert_eq!(

--- a/catserver/src/server/radio_configuration.rs
+++ b/catserver/src/server/radio_configuration.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     args::{DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_PORT},
-    radio_config::{HamlibConfig, HamlibRigConfig, RadioBackendKind, RadioConfig},
+    radio_config::{
+        HamlibRigConfig, LegacyHamlibConfig, LegacyRadioConfig, RadioBackendKind, RadioConfig,
+        RadioRigConfig,
+    },
     radio_factory,
     radio_manager::RadioManager,
 };
@@ -66,7 +69,7 @@ impl RadioConfigurationService for ProductionRadioConfiguration {
     fn capabilities(&self) -> Capabilities {
         Capabilities {
             radio_configuration: true,
-            backends: vec!["omnirig", "rigctld", "hamlib"],
+            backends: supported_backends(),
         }
     }
 
@@ -133,21 +136,24 @@ impl RadioConfigurationService for ProductionRadioConfiguration {
 }
 
 fn validate_configuration(configuration: &RadioConfig) -> Result<(), FieldError> {
-    configuration.validate().map_err(|error| FieldError {
-        field: config_field(&error),
-        message: error.to_string(),
-        token: config_token(&error),
-    })?;
-    if let Some(hamlib) = &configuration.hamlib {
-        validate_hamlib(hamlib)?;
+    validate_rig_configuration("rig1", &configuration.rig1)?;
+    if let Some(rig2) = &configuration.rig2 {
+        validate_rig_configuration("rig2", rig2)?;
     }
     Ok(())
 }
 
-fn validate_hamlib(configuration: &HamlibConfig) -> Result<(), FieldError> {
-    validate_rig("hamlib.rig1", &configuration.rig1)?;
-    if let Some(rig2) = &configuration.rig2 {
-        validate_rig("hamlib.rig2", rig2)?;
+fn validate_rig_configuration(
+    field: &str,
+    configuration: &RadioRigConfig,
+) -> Result<(), FieldError> {
+    configuration.validate().map_err(|error| FieldError {
+        field: config_field(field, &error),
+        message: error.to_string(),
+        token: config_token(&error),
+    })?;
+    if let Some(hamlib) = &configuration.hamlib {
+        validate_rig(&format!("{field}.hamlib"), hamlib)?;
     }
     Ok(())
 }
@@ -199,16 +205,38 @@ pub(super) fn parse_backend(value: &str) -> Result<RadioBackendKind, FieldError>
 
 #[derive(Deserialize)]
 pub(super) struct ConfigurationInput {
-    pub(super) backend: String,
     #[serde(default)]
-    pub(super) hamlib: Option<crate::radio_config::HamlibConfig>,
+    pub(super) rig1: Option<RadioRigConfig>,
+    #[serde(default)]
+    pub(super) rig2: Option<RadioRigConfig>,
+    #[serde(default)]
+    pub(super) backend: Option<String>,
+    #[serde(default)]
+    pub(super) hamlib: Option<LegacyHamlibConfig>,
 }
 
 impl ConfigurationInput {
     pub(super) fn into_config(self) -> Result<RadioConfig, FieldError> {
-        Ok(RadioConfig {
-            backend: parse_backend(&self.backend)?,
+        if let Some(rig1) = self.rig1 {
+            return Ok(RadioConfig {
+                rig1,
+                rig2: self.rig2,
+            });
+        }
+        let backend = self.backend.ok_or_else(|| FieldError {
+            field: "rig1".into(),
+            message: "missing rig 1 configuration".into(),
+            token: None,
+        })?;
+        parse_backend(&backend)?;
+        RadioConfig::from_legacy(LegacyRadioConfig {
+            backend,
             hamlib: self.hamlib,
+        })
+        .map_err(|error| FieldError {
+            field: config_field("rig1", &error),
+            message: error.to_string(),
+            token: config_token(&error),
         })
     }
 }
@@ -245,19 +273,31 @@ fn manager_error(error: crate::radio_manager::RadioManagerError) -> FieldError {
     }
 }
 
-fn config_field(error: &crate::radio_config::RadioConfigError) -> String {
+fn config_field(field: &str, error: &crate::radio_config::RadioConfigError) -> String {
     use crate::radio_config::RadioConfigError::*;
     match error {
-        InvalidModelId(_) => "hamlib.rig1.model_id",
-        InvalidToken(_) => "hamlib.rig1.token_values",
-        _ => "backend",
+        InvalidModelId(_) => format!("{field}.hamlib.model_id"),
+        InvalidToken(_) => format!("{field}.hamlib.token_values"),
+        InvalidRigctldHost(_) => format!("{field}.rigctld.host"),
+        InvalidRigctldPort => format!("{field}.rigctld.port"),
+        _ => format!("{field}.backend"),
     }
-    .into()
 }
 
 fn config_token(error: &crate::radio_config::RadioConfigError) -> Option<String> {
     match error {
         crate::radio_config::RadioConfigError::InvalidToken(token) => Some(token.clone()),
         _ => None,
+    }
+}
+
+fn supported_backends() -> Vec<&'static str> {
+    #[cfg(windows)]
+    {
+        vec!["omnirig", "hamlib"]
+    }
+    #[cfg(not(windows))]
+    {
+        vec!["rigctld", "hamlib"]
     }
 }

--- a/ui/src/components/settings/CatControl.jsx
+++ b/ui/src/components/settings/CatControl.jsx
@@ -2,8 +2,8 @@ import Input from "@/components/ui/Input.jsx";
 import Select from "@/components/ui/Select.jsx";
 import Toggle from "@/components/ui/Toggle.jsx";
 import use_radio from "@/hooks/useRadio";
-import LoggerIntegrationHelp from "./LoggerIntegrationHelp.jsx";
 import { useEffect, useState } from "react";
+import LoggerIntegrationHelp from "./LoggerIntegrationHelp.jsx";
 
 const serial_labels = {
     rig_pathname: "Serial port",

--- a/ui/src/components/settings/CatControl.jsx
+++ b/ui/src/components/settings/CatControl.jsx
@@ -1,45 +1,83 @@
 import Input from "@/components/ui/Input.jsx";
-import Modal from "@/components/ui/Modal.jsx";
 import Select from "@/components/ui/Select.jsx";
 import Toggle from "@/components/ui/Toggle.jsx";
 import use_radio from "@/hooks/useRadio";
 import LoggerIntegrationHelp from "./LoggerIntegrationHelp.jsx";
 import { useEffect, useState } from "react";
 
-function empty_rig() {
+const serial_labels = {
+    rig_pathname: "Serial port",
+    pathname: "Serial port",
+    device: "Serial port",
+    serial_speed: "Baud rate",
+    baud: "Baud rate",
+    data_bits: "Data bits",
+    stop_bits: "Stop bits",
+    parity: "Parity",
+    serial_handshake: "Handshake",
+    rts: "Force Control RTS",
+    dtr: "Force Control DTR",
+};
+
+function empty_hamlib() {
     return { model_id: "", token_values: {} };
 }
 
-function normalized_configuration(configuration) {
+function empty_rig() {
+    return {
+        backend: "rigctld",
+        hamlib: empty_hamlib(),
+        rigctld: { host: "127.0.0.1", port: "4532" },
+    };
+}
+
+function normalize_rig(rig) {
+    const fallback = empty_rig();
+    return {
+        ...fallback,
+        ...rig,
+        hamlib: { ...fallback.hamlib, ...rig?.hamlib },
+        rigctld: {
+            ...fallback.rigctld,
+            ...rig?.rigctld,
+            port: String(rig?.rigctld?.port ?? fallback.rigctld.port),
+        },
+    };
+}
+
+function normalize_configuration(configuration) {
     if (configuration == null) {
         return null;
     }
 
     return {
-        backend: configuration.backend || "omnirig",
-        hamlib:
-            configuration.hamlib == null
-                ? null
-                : {
-                      rig1: configuration.hamlib.rig1 || empty_rig(),
-                      rig2: configuration.hamlib.rig2 || null,
-                  },
+        rig1: normalize_rig(configuration.rig1),
+        rig2: normalize_rig(configuration.rig2),
+        rig2_enabled: configuration.rig2 != null,
     };
 }
 
-function update_rig(configuration, rig, update) {
-    return {
-        ...configuration,
-        hamlib: {
-            ...configuration.hamlib,
-            [rig]: update(configuration.hamlib[rig]),
-        },
-    };
+function serialized_rig(rig) {
+    if (rig.backend === "hamlib") {
+        return { backend: "hamlib", hamlib: rig.hamlib };
+    }
+    if (rig.backend === "rigctld") {
+        return {
+            backend: "rigctld",
+            rigctld: { ...rig.rigctld, port: Number.parseInt(rig.rigctld.port, 10) },
+        };
+    }
+    return { backend: rig.backend };
+}
+
+function error_for_rig(error, rig) {
+    return error?.field?.startsWith(`${rig}.`) ? error : null;
 }
 
 function DescriptorInput({ descriptor, value, on_change, error_token }) {
     const input_id = `hamlib-${descriptor.token}`;
     const invalid = error_token === descriptor.token;
+    const label = serial_labels[descriptor.token] || descriptor.label;
     const input_class = invalid ? "bg-red-200" : "";
 
     if (descriptor.kind === "boolean") {
@@ -55,14 +93,14 @@ function DescriptorInput({ descriptor, value, on_change, error_token }) {
                     type="checkbox"
                     onChange={event => on_change(String(event.target.checked))}
                 />
-                {descriptor.label}
+                {label}
             </label>
         );
     }
 
     return (
         <label className="flex flex-col gap-1" title={descriptor.tooltip} htmlFor={input_id}>
-            <span>{descriptor.label}</span>
+            <span>{label}</span>
             {descriptor.kind === "combo" ? (
                 <Select
                     id={input_id}
@@ -98,91 +136,38 @@ function DescriptorInput({ descriptor, value, on_change, error_token }) {
     );
 }
 
-function RigSettings({ rig, configuration, models, descriptors, error, set_configuration }) {
-    const rig_configuration = configuration.hamlib[rig];
-    const model_id = rig_configuration.model_id;
-    const model_list_id = `${rig}-hamlib-models`;
-
-    return (
-        <fieldset className="border rounded p-3 flex flex-col gap-3">
-            <legend>{rig === "rig1" ? "Rig 1" : "Rig 2"}</legend>
-            <label className="flex flex-col gap-1" htmlFor={`${rig}-model`}>
-                <span>Model</span>
-                <Input
-                    id={`${rig}-model`}
-                    list={model_list_id}
-                    type="search"
-                    className={error?.field === `hamlib.${rig}.model_id` ? "bg-red-200" : ""}
-                    value={model_id}
-                    onChange={event =>
-                        set_configuration(current =>
-                            update_rig(current, rig, current_rig => ({
-                                ...current_rig,
-                                model_id: event.target.value,
-                                token_values: {},
-                            })),
-                        )
-                    }
-                />
-                <datalist id={model_list_id}>
-                    {models.map(model => (
-                        <option key={model.id} value={model.id}>
-                            {model.manufacturer} {model.model}
-                        </option>
-                    ))}
-                </datalist>
-            </label>
-            {descriptors?.map(descriptor => (
-                <DescriptorInput
-                    key={descriptor.token}
-                    descriptor={descriptor}
-                    error_token={error?.token}
-                    value={
-                        rig_configuration.token_values[descriptor.token] ??
-                        String(descriptor.default)
-                    }
-                    on_change={value =>
-                        set_configuration(current =>
-                            update_rig(current, rig, current_rig => ({
-                                ...current_rig,
-                                token_values: {
-                                    ...current_rig.token_values,
-                                    [descriptor.token]: value,
-                                },
-                            })),
-                        )
-                    }
-                />
-            ))}
-        </fieldset>
-    );
-}
-
 function CatControl({ temp_settings, set_temp_settings, colors }) {
     const {
         radio_capabilities,
         radio_configuration,
         radio_configuration_result,
-        radio_retry_result,
-        radio_status,
         hamlib_models,
         hamlib_models_error,
-        hamlib_model_detail,
         hamlib_model_details,
         hamlib_model_error,
         get_radio_configuration,
         list_hamlib_models,
         describe_hamlib_model,
         set_radio_configuration,
-        retry_radio,
     } = use_radio();
     const [configuration, set_configuration] = useState(null);
-
+    const [selected_rig, set_selected_rig] = useState("rig1");
+    const [save_state, set_save_state] = useState(null);
+    const [logger_port_touched, set_logger_port_touched] = useState(false);
+    const [rigctld_port_touched, set_rigctld_port_touched] = useState(false);
     const configuration_capable = radio_capabilities?.radio_configuration === true;
-    const configuration_error =
+    const available_backends = radio_capabilities?.backends || [];
+    const selected_configuration = configuration?.[selected_rig];
+    const server_error =
         radio_configuration_result?.ok === false ? radio_configuration_result.error : null;
-    const rig1_model_id = configuration?.hamlib?.rig1?.model_id;
-    const rig2_model_id = configuration?.hamlib?.rig2?.model_id;
+    const selected_error = error_for_rig(server_error, selected_rig);
+    const rigctld_port_valid =
+        Number.isInteger(Number(selected_configuration?.rigctld.port)) &&
+        Number(selected_configuration?.rigctld.port) >= 1 &&
+        Number(selected_configuration?.rigctld.port) <= 65535;
+    const rigctld_host_valid = selected_configuration?.rigctld.host.trim().length > 0;
+    const logger_port_valid =
+        temp_settings.highlight_port >= 1024 && temp_settings.highlight_port <= 65535;
 
     useEffect(() => {
         if (configuration_capable) {
@@ -192,202 +177,302 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
     }, [configuration_capable]);
 
     useEffect(() => {
-        set_configuration(normalized_configuration(radio_configuration));
+        set_configuration(normalize_configuration(radio_configuration));
     }, [radio_configuration]);
 
     useEffect(() => {
-        if (configuration?.backend !== "hamlib") {
-            return;
+        if (
+            selected_configuration?.backend === "hamlib" &&
+            selected_configuration.hamlib.model_id
+        ) {
+            describe_hamlib_model(selected_configuration.hamlib.model_id);
         }
+    }, [selected_configuration?.backend, selected_configuration?.hamlib.model_id]);
 
-        [rig1_model_id, rig2_model_id].filter(Boolean).forEach(describe_hamlib_model);
-    }, [configuration?.backend, rig1_model_id, rig2_model_id]);
+    useEffect(() => {
+        if (radio_configuration_result?.ok === true) {
+            set_save_state({ ok: true, message: "Radio hardware saved." });
+        } else if (server_error && error_for_rig(server_error, selected_rig)) {
+            set_save_state({ ok: false, message: server_error.message });
+        }
+    }, [radio_configuration_result, selected_rig]);
 
-    const is_port_valid =
-        temp_settings.highlight_port >= 1024 && temp_settings.highlight_port <= 65535;
-
-    function select_backend(backend) {
+    function update_selected(update) {
+        set_save_state(null);
         set_configuration(current => ({
-            backend,
-            hamlib:
-                backend === "hamlib" ? current?.hamlib || { rig1: empty_rig(), rig2: null } : null,
+            ...current,
+            [selected_rig]: update(current[selected_rig]),
         }));
     }
 
-    function apply_configuration() {
-        if (configuration?.backend === "hamlib" && !configuration.hamlib.rig1.model_id) {
+    function validate_selected_rig() {
+        if (selected_configuration.backend === "hamlib") {
+            return selected_configuration.hamlib.model_id.trim().length > 0;
+        }
+        return (
+            selected_configuration.backend !== "rigctld" ||
+            (rigctld_host_valid && rigctld_port_valid)
+        );
+    }
+
+    function save_configuration() {
+        set_rigctld_port_touched(true);
+        if (!validate_selected_rig()) {
+            set_save_state({
+                ok: false,
+                message: "Fix the highlighted radio settings before saving.",
+            });
             return;
         }
-        set_radio_configuration(configuration);
+        set_save_state({ ok: null, message: "Saving radio hardware..." });
+        set_radio_configuration({
+            rig1: serialized_rig(configuration.rig1),
+            ...(configuration.rig2_enabled ? { rig2: serialized_rig(configuration.rig2) } : {}),
+        });
     }
 
     return (
-        <>
-            <div className="p-4" data-tour="settings-cat-control">
-                {configuration_capable && configuration != null ? (
-                    <section
-                        className="mb-6 flex flex-col gap-3"
-                        aria-label="Radio hardware settings"
-                    >
-                        <h4 className="text-lg">Radio hardware</h4>
+        <div className="p-4" data-tour="settings-cat-control">
+            {configuration_capable && configuration != null ? (
+                <section className="mb-6 flex flex-col gap-4" aria-label="Radio hardware settings">
+                    <h4 className="text-lg">Radio hardware</h4>
+                    <div className="grid gap-3 min-[720px]:grid-cols-2">
+                        <label className="flex flex-col gap-1" htmlFor="radio-rig">
+                            <span>Rig</span>
+                            <select
+                                id="radio-rig"
+                                className="rounded-lg px-4 py-2"
+                                value={selected_rig}
+                                onChange={event => {
+                                    set_selected_rig(event.target.value);
+                                    set_rigctld_port_touched(false);
+                                    set_save_state(null);
+                                }}
+                            >
+                                <option value="rig1">Rig 1</option>
+                                <option value="rig2">Rig 2</option>
+                            </select>
+                        </label>
                         <label className="flex flex-col gap-1" htmlFor="radio-backend">
                             <span>Backend</span>
                             <Select
                                 id="radio-backend"
-                                value={configuration.backend}
+                                value={selected_configuration.backend}
                                 className={
-                                    configuration_error?.field === "backend" ? "bg-red-200" : ""
+                                    selected_error?.field === `${selected_rig}.backend`
+                                        ? "bg-red-200"
+                                        : ""
                                 }
-                                onChange={event => select_backend(event.target.value)}
+                                onChange={event =>
+                                    update_selected(rig => ({
+                                        ...rig,
+                                        backend: event.target.value,
+                                    }))
+                                }
                             >
-                                {radio_capabilities.backends.map(backend => (
+                                {available_backends.map(backend => (
                                     <option key={backend} value={backend}>
                                         {backend}
                                     </option>
                                 ))}
                             </Select>
                         </label>
-                        {configuration.backend === "hamlib" ? (
-                            <>
-                                {hamlib_models_error != null ? (
-                                    <p role="alert">{hamlib_models_error.message}</p>
-                                ) : null}
-                                <RigSettings
-                                    rig="rig1"
-                                    configuration={configuration}
-                                    models={hamlib_models}
-                                    descriptors={
-                                        hamlib_model_details[rig1_model_id] || hamlib_model_detail
+                    </div>
+                    {selected_rig === "rig2" ? (
+                        <label className="flex items-center gap-2" htmlFor="enable-rig2">
+                            <input
+                                id="enable-rig2"
+                                type="checkbox"
+                                checked={configuration.rig2_enabled}
+                                onChange={event =>
+                                    set_configuration(current => ({
+                                        ...current,
+                                        rig2_enabled: event.target.checked,
+                                    }))
+                                }
+                            />
+                            Enable Rig 2
+                        </label>
+                    ) : null}
+                    {selected_configuration.backend === "rigctld" ? (
+                        <div className="grid gap-3 min-[720px]:grid-cols-2">
+                            <label className="flex flex-col gap-1" htmlFor="rigctld-host">
+                                <span>Host</span>
+                                <Input
+                                    id="rigctld-host"
+                                    className={
+                                        !rigctld_host_valid ||
+                                        selected_error?.field === `${selected_rig}.rigctld.host`
+                                            ? "bg-red-200 w-full"
+                                            : "w-full"
                                     }
-                                    error={
-                                        configuration_error?.field?.startsWith("hamlib.rig1")
-                                            ? configuration_error
-                                            : null
+                                    value={selected_configuration.rigctld.host}
+                                    onChange={event =>
+                                        update_selected(rig => ({
+                                            ...rig,
+                                            rigctld: { ...rig.rigctld, host: event.target.value },
+                                        }))
                                     }
-                                    set_configuration={set_configuration}
                                 />
-                                {hamlib_model_error != null ? (
-                                    <p role="alert">{hamlib_model_error.message}</p>
-                                ) : null}
-                                {configuration.hamlib.rig2 == null ? (
-                                    <button
-                                        type="button"
-                                        className="self-start"
-                                        onClick={() =>
-                                            set_configuration(current => ({
-                                                ...current,
-                                                hamlib: { ...current.hamlib, rig2: empty_rig() },
+                            </label>
+                            <label className="flex flex-col gap-1" htmlFor="rigctld-port">
+                                <span>Port</span>
+                                <Input
+                                    id="rigctld-port"
+                                    className={
+                                        rigctld_port_touched &&
+                                        (!rigctld_port_valid ||
+                                            selected_error?.field ===
+                                                `${selected_rig}.rigctld.port`)
+                                            ? "bg-red-200"
+                                            : ""
+                                    }
+                                    type="number"
+                                    min="1"
+                                    max="65535"
+                                    step="1"
+                                    value={selected_configuration.rigctld.port}
+                                    onChange={event =>
+                                        update_selected(rig => ({
+                                            ...rig,
+                                            rigctld: { ...rig.rigctld, port: event.target.value },
+                                        }))
+                                    }
+                                    onBlur={() => set_rigctld_port_touched(true)}
+                                />
+                            </label>
+                        </div>
+                    ) : null}
+                    {selected_configuration.backend === "hamlib" ? (
+                        <div className="flex flex-col gap-3">
+                            {hamlib_models_error ? (
+                                <p role="alert">{hamlib_models_error.message}</p>
+                            ) : null}
+                            <label className="flex flex-col gap-1" htmlFor="hamlib-model">
+                                <span>Model</span>
+                                <Input
+                                    id="hamlib-model"
+                                    list="hamlib-models"
+                                    type="search"
+                                    className={
+                                        selected_error?.field === `${selected_rig}.hamlib.model_id`
+                                            ? "bg-red-200 w-full"
+                                            : "w-full"
+                                    }
+                                    value={selected_configuration.hamlib.model_id}
+                                    onChange={event =>
+                                        update_selected(rig => ({
+                                            ...rig,
+                                            hamlib: {
+                                                ...rig.hamlib,
+                                                model_id: event.target.value,
+                                                token_values: {},
+                                            },
+                                        }))
+                                    }
+                                />
+                                <datalist id="hamlib-models">
+                                    {hamlib_models.map(model => (
+                                        <option key={model.id} value={model.id}>
+                                            {model.manufacturer} {model.model}
+                                        </option>
+                                    ))}
+                                </datalist>
+                            </label>
+                            <h5 className="border-t pt-3 font-semibold">Serial connection</h5>
+                            <div className="grid gap-3 min-[720px]:grid-cols-2">
+                                {(
+                                    hamlib_model_details[selected_configuration.hamlib.model_id] ||
+                                    []
+                                ).map(descriptor => (
+                                    <DescriptorInput
+                                        key={descriptor.token}
+                                        descriptor={descriptor}
+                                        error_token={selected_error?.token}
+                                        value={
+                                            selected_configuration.hamlib.token_values[
+                                                descriptor.token
+                                            ] ?? String(descriptor.default)
+                                        }
+                                        on_change={value =>
+                                            update_selected(rig => ({
+                                                ...rig,
+                                                hamlib: {
+                                                    ...rig.hamlib,
+                                                    token_values: {
+                                                        ...rig.hamlib.token_values,
+                                                        [descriptor.token]: value,
+                                                    },
+                                                },
                                             }))
                                         }
-                                    >
-                                        Add Rig 2
-                                    </button>
-                                ) : (
-                                    <>
-                                        <RigSettings
-                                            rig="rig2"
-                                            configuration={configuration}
-                                            models={hamlib_models}
-                                            descriptors={
-                                                hamlib_model_details[rig2_model_id] ||
-                                                hamlib_model_detail
-                                            }
-                                            error={
-                                                configuration_error?.field?.startsWith(
-                                                    "hamlib.rig2",
-                                                )
-                                                    ? configuration_error
-                                                    : null
-                                            }
-                                            set_configuration={set_configuration}
-                                        />
-                                        <button
-                                            type="button"
-                                            className="self-start"
-                                            onClick={() =>
-                                                set_configuration(current => ({
-                                                    ...current,
-                                                    hamlib: { ...current.hamlib, rig2: null },
-                                                }))
-                                            }
-                                        >
-                                            Remove Rig 2
-                                        </button>
-                                    </>
-                                )}
-                            </>
-                        ) : null}
-                        {configuration_error != null ? (
-                            <p role="alert">{configuration_error.message}</p>
-                        ) : null}
-                        {radio_status === "disconnected" ? (
-                            <div className="flex items-center gap-2">
-                                <span>Radio disconnected</span>
-                                <button type="button" onClick={retry_radio}>
-                                    Retry
-                                </button>
-                                {radio_retry_result?.ok === false ? (
-                                    <span role="alert">{radio_retry_result.error?.message}</span>
-                                ) : null}
+                                    />
+                                ))}
                             </div>
-                        ) : null}
-                        <button
-                            type="button"
-                            className="self-start"
-                            disabled={
-                                configuration.backend === "hamlib" &&
-                                !configuration.hamlib.rig1.model_id
-                            }
-                            onClick={apply_configuration}
-                        >
-                            Apply radio hardware
-                        </button>
-                    </section>
-                ) : null}
-                <table
-                    className="table-fixed border-separate border-spacing-y-2"
-                    style={{ color: colors.theme.text }}
-                >
-                    <tbody>
-                        <tr>
-                            <td>Enable logger integration:&nbsp;&nbsp;</td>
-                            <td className="flex gap-2">
-                                <Toggle
-                                    value={temp_settings.highlight_enabled}
-                                    data_tour="settings-cat-logger-toggle"
-                                    on_click={() => {
-                                        set_temp_settings({
-                                            ...temp_settings,
-                                            highlight_enabled: !temp_settings.highlight_enabled,
-                                        });
-                                    }}
-                                />
-                                <LoggerIntegrationHelp colors={colors} />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>UDP Port:</td>
-                            <td>
-                                <Input
-                                    value={temp_settings.highlight_port}
-                                    className={is_port_valid ? "" : "bg-red-200"}
-                                    data-tour="settings-cat-udp-port"
-                                    type="number"
-                                    min="1024"
-                                    max="65535"
-                                    onChange={event => {
-                                        set_temp_settings({
-                                            ...temp_settings,
-                                            highlight_port: Number.parseInt(event.target.value),
-                                        });
-                                    }}
-                                />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </>
+                            {hamlib_model_error ? (
+                                <p role="alert">{hamlib_model_error.message}</p>
+                            ) : null}
+                        </div>
+                    ) : null}
+                    {selected_error ? <p role="alert">{selected_error.message}</p> : null}
+                    {save_state &&
+                    (!selected_error || save_state.message !== selected_error.message) ? (
+                        <p role={save_state.ok === false ? "alert" : "status"}>
+                            {save_state.message}
+                        </p>
+                    ) : null}
+                    <button type="button" className="self-start" onClick={save_configuration}>
+                        Save radio hardware
+                    </button>
+                </section>
+            ) : null}
+            <h4 className="mb-2 border-t pt-4 text-lg">Logger integration</h4>
+            <table
+                className="table-fixed border-separate border-spacing-y-2"
+                style={{ color: colors.theme.text }}
+            >
+                <tbody>
+                    <tr>
+                        <td>Enable logger integration:&nbsp;&nbsp;</td>
+                        <td className="flex gap-2">
+                            <Toggle
+                                value={temp_settings.highlight_enabled}
+                                data_tour="settings-cat-logger-toggle"
+                                on_click={() =>
+                                    set_temp_settings({
+                                        ...temp_settings,
+                                        highlight_enabled: !temp_settings.highlight_enabled,
+                                    })
+                                }
+                            />
+                            <LoggerIntegrationHelp colors={colors} />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>UDP Port:</td>
+                        <td>
+                            <Input
+                                value={temp_settings.highlight_port}
+                                className={
+                                    logger_port_touched && !logger_port_valid ? "bg-red-200" : ""
+                                }
+                                data-tour="settings-cat-udp-port"
+                                type="number"
+                                min="1024"
+                                max="65535"
+                                onChange={event =>
+                                    set_temp_settings({
+                                        ...temp_settings,
+                                        highlight_port: Number.parseInt(event.target.value, 10),
+                                    })
+                                }
+                                onBlur={() => set_logger_port_touched(true)}
+                            />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     );
 }
 

--- a/ui/src/components/settings/CatControl.jsx
+++ b/ui/src/components/settings/CatControl.jsx
@@ -19,6 +19,16 @@ const serial_labels = {
     dtr: "Force Control DTR",
 };
 
+function serial_descriptors(descriptors) {
+    return descriptors
+        .filter(descriptor => Object.hasOwn(serial_labels, descriptor.token))
+        .sort(
+            (left, right) =>
+                Object.keys(serial_labels).indexOf(left.token) -
+                Object.keys(serial_labels).indexOf(right.token),
+        );
+}
+
 function empty_hamlib() {
     return { model_id: "", token_values: {} };
 }
@@ -239,9 +249,9 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
                     <div className="grid gap-3 min-[720px]:grid-cols-2">
                         <label className="flex flex-col gap-1" htmlFor="radio-rig">
                             <span>Rig</span>
-                            <select
+                            <Select
                                 id="radio-rig"
-                                className="rounded-lg px-4 py-2"
+                                className="w-full"
                                 value={selected_rig}
                                 onChange={event => {
                                     set_selected_rig(event.target.value);
@@ -251,7 +261,7 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
                             >
                                 <option value="rig1">Rig 1</option>
                                 <option value="rig2">Rig 2</option>
-                            </select>
+                            </Select>
                         </label>
                         <label className="flex flex-col gap-1" htmlFor="radio-backend">
                             <span>Backend</span>
@@ -350,40 +360,42 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
                             ) : null}
                             <label className="flex flex-col gap-1" htmlFor="hamlib-model">
                                 <span>Model</span>
-                                <Input
+                                <Select
                                     id="hamlib-model"
-                                    list="hamlib-models"
-                                    type="search"
                                     className={
                                         selected_error?.field === `${selected_rig}.hamlib.model_id`
                                             ? "bg-red-200 w-full"
                                             : "w-full"
                                     }
                                     value={selected_configuration.hamlib.model_id}
-                                    onChange={event =>
+                                    onChange={event => {
+                                        const model_id = event.target.value;
                                         update_selected(rig => ({
                                             ...rig,
                                             hamlib: {
                                                 ...rig.hamlib,
-                                                model_id: event.target.value,
-                                                token_values: {},
+                                                model_id,
+                                                token_values:
+                                                    model_id === rig.hamlib.model_id
+                                                        ? rig.hamlib.token_values
+                                                        : {},
                                             },
-                                        }))
-                                    }
-                                />
-                                <datalist id="hamlib-models">
+                                        }));
+                                    }}
+                                >
+                                    <option value="">Select a model</option>
                                     {hamlib_models.map(model => (
                                         <option key={model.id} value={model.id}>
                                             {model.manufacturer} {model.model}
                                         </option>
                                     ))}
-                                </datalist>
+                                </Select>
                             </label>
                             <h5 className="border-t pt-3 font-semibold">Serial connection</h5>
                             <div className="grid gap-3 min-[720px]:grid-cols-2">
-                                {(
+                                {serial_descriptors(
                                     hamlib_model_details[selected_configuration.hamlib.model_id] ||
-                                    []
+                                        [],
                                 ).map(descriptor => (
                                     <DescriptorInput
                                         key={descriptor.token}

--- a/ui/src/components/settings/CatControl.jsx
+++ b/ui/src/components/settings/CatControl.jsx
@@ -1,18 +1,321 @@
 import Input from "@/components/ui/Input.jsx";
+import Modal from "@/components/ui/Modal.jsx";
+import Select from "@/components/ui/Select.jsx";
 import Toggle from "@/components/ui/Toggle.jsx";
 import use_radio from "@/hooks/useRadio";
-import { useState } from "react";
 import LoggerIntegrationHelp from "./LoggerIntegrationHelp.jsx";
+import { useEffect, useState } from "react";
+
+function empty_rig() {
+    return { model_id: "", token_values: {} };
+}
+
+function normalized_configuration(configuration) {
+    if (configuration == null) {
+        return null;
+    }
+
+    return {
+        backend: configuration.backend || "omnirig",
+        hamlib:
+            configuration.hamlib == null
+                ? null
+                : {
+                      rig1: configuration.hamlib.rig1 || empty_rig(),
+                      rig2: configuration.hamlib.rig2 || null,
+                  },
+    };
+}
+
+function update_rig(configuration, rig, update) {
+    return {
+        ...configuration,
+        hamlib: {
+            ...configuration.hamlib,
+            [rig]: update(configuration.hamlib[rig]),
+        },
+    };
+}
+
+function DescriptorInput({ descriptor, value, on_change, error_token }) {
+    const input_id = `hamlib-${descriptor.token}`;
+    const invalid = error_token === descriptor.token;
+    const input_class = invalid ? "bg-red-200" : "";
+
+    if (descriptor.kind === "boolean") {
+        return (
+            <label className="flex items-center gap-2" title={descriptor.tooltip} htmlFor={input_id}>
+                <input
+                    id={input_id}
+                    checked={value === "true"}
+                    type="checkbox"
+                    onChange={event => on_change(String(event.target.checked))}
+                />
+                {descriptor.label}
+            </label>
+        );
+    }
+
+    return (
+        <label className="flex flex-col gap-1" title={descriptor.tooltip} htmlFor={input_id}>
+            <span>{descriptor.label}</span>
+            {descriptor.kind === "combo" ? (
+                <Select
+                    id={input_id}
+                    aria-invalid={invalid}
+                    className={input_class}
+                    value={value}
+                    onChange={event => on_change(event.target.value)}
+                >
+                    {descriptor.options.map(option => (
+                        <option key={option} value={option}>
+                            {option}
+                        </option>
+                    ))}
+                </Select>
+            ) : (
+                <Input
+                    id={input_id}
+                    aria-invalid={invalid}
+                    className={input_class}
+                    type={descriptor.kind === "integer" || descriptor.kind === "numeric" ? "number" : "text"}
+                    min={descriptor.minimum}
+                    max={descriptor.maximum}
+                    step={descriptor.step}
+                    value={value}
+                    onChange={event => on_change(event.target.value)}
+                />
+            )}
+        </label>
+    );
+}
+
+function RigSettings({ rig, configuration, models, descriptors, error, set_configuration }) {
+    const rig_configuration = configuration.hamlib[rig];
+    const model_id = rig_configuration.model_id;
+    const model_list_id = `${rig}-hamlib-models`;
+
+    return (
+        <fieldset className="border rounded p-3 flex flex-col gap-3">
+            <legend>{rig === "rig1" ? "Rig 1" : "Rig 2"}</legend>
+            <label className="flex flex-col gap-1" htmlFor={`${rig}-model`}>
+                <span>Model</span>
+                <Input
+                    id={`${rig}-model`}
+                    list={model_list_id}
+                    type="search"
+                    className={error?.field === `hamlib.${rig}.model_id` ? "bg-red-200" : ""}
+                    value={model_id}
+                    onChange={event =>
+                        set_configuration(current =>
+                            update_rig(current, rig, current_rig => ({
+                                ...current_rig,
+                                model_id: event.target.value,
+                                token_values: {},
+                            })),
+                        )
+                    }
+                />
+                <datalist id={model_list_id}>
+                    {models.map(model => (
+                        <option key={model.id} value={model.id}>
+                            {model.manufacturer} {model.model}
+                        </option>
+                    ))}
+                </datalist>
+            </label>
+            {descriptors?.map(descriptor => (
+                <DescriptorInput
+                    key={descriptor.token}
+                    descriptor={descriptor}
+                    error_token={error?.token}
+                    value={rig_configuration.token_values[descriptor.token] ?? String(descriptor.default)}
+                    on_change={value =>
+                        set_configuration(current =>
+                            update_rig(current, rig, current_rig => ({
+                                ...current_rig,
+                                token_values: { ...current_rig.token_values, [descriptor.token]: value },
+                            })),
+                        )
+                    }
+                />
+            ))}
+        </fieldset>
+    );
+}
 
 function CatControl({ temp_settings, set_temp_settings, colors }) {
-    const { is_radio_available } = use_radio();
+    const {
+        radio_capabilities,
+        radio_configuration,
+        radio_configuration_result,
+        radio_retry_result,
+        radio_status,
+        hamlib_models,
+        hamlib_models_error,
+        hamlib_model_detail,
+        hamlib_model_details,
+        hamlib_model_error,
+        get_radio_configuration,
+        list_hamlib_models,
+        describe_hamlib_model,
+        set_radio_configuration,
+        retry_radio,
+    } = use_radio();
+    const [configuration, set_configuration] = useState(null);
+
+    const configuration_capable = radio_capabilities?.radio_configuration === true;
+    const configuration_error = radio_configuration_result?.ok === false ? radio_configuration_result.error : null;
+    const rig1_model_id = configuration?.hamlib?.rig1?.model_id;
+    const rig2_model_id = configuration?.hamlib?.rig2?.model_id;
+
+    useEffect(() => {
+        if (configuration_capable) {
+            get_radio_configuration();
+            list_hamlib_models();
+        }
+    }, [configuration_capable]);
+
+    useEffect(() => {
+        set_configuration(normalized_configuration(radio_configuration));
+    }, [radio_configuration]);
+
+    useEffect(() => {
+        if (configuration?.backend !== "hamlib") {
+            return;
+        }
+
+        [rig1_model_id, rig2_model_id].filter(Boolean).forEach(describe_hamlib_model);
+    }, [configuration?.backend, rig1_model_id, rig2_model_id]);
 
     const is_port_valid =
         temp_settings.highlight_port >= 1024 && temp_settings.highlight_port <= 65535;
 
+    function select_backend(backend) {
+        set_configuration(current => ({
+            backend,
+            hamlib:
+                backend === "hamlib"
+                    ? current?.hamlib || { rig1: empty_rig(), rig2: null }
+                    : null,
+        }));
+    }
+
+    function apply_configuration() {
+        if (configuration?.backend === "hamlib" && !configuration.hamlib.rig1.model_id) {
+            return;
+        }
+        set_radio_configuration(configuration);
+    }
+
     return (
         <>
             <div className="p-4" data-tour="settings-cat-control">
+                {configuration_capable && configuration != null ? (
+                    <section className="mb-6 flex flex-col gap-3" aria-label="Radio hardware settings">
+                        <h4 className="text-lg">Radio hardware</h4>
+                        <label className="flex flex-col gap-1" htmlFor="radio-backend">
+                            <span>Backend</span>
+                            <Select
+                                id="radio-backend"
+                                value={configuration.backend}
+                                className={configuration_error?.field === "backend" ? "bg-red-200" : ""}
+                                onChange={event => select_backend(event.target.value)}
+                            >
+                                {radio_capabilities.backends.map(backend => (
+                                    <option key={backend} value={backend}>
+                                        {backend}
+                                    </option>
+                                ))}
+                            </Select>
+                        </label>
+                        {configuration.backend === "hamlib" ? (
+                            <>
+                                {hamlib_models_error != null ? (
+                                    <p role="alert">{hamlib_models_error.message}</p>
+                                ) : null}
+                                <RigSettings
+                                    rig="rig1"
+                                    configuration={configuration}
+                                    models={hamlib_models}
+                                    descriptors={hamlib_model_details[rig1_model_id] || hamlib_model_detail}
+                                    error={
+                                        configuration_error?.field?.startsWith("hamlib.rig1")
+                                            ? configuration_error
+                                            : null
+                                    }
+                                    set_configuration={set_configuration}
+                                />
+                                {hamlib_model_error != null ? (
+                                    <p role="alert">{hamlib_model_error.message}</p>
+                                ) : null}
+                                {configuration.hamlib.rig2 == null ? (
+                                    <button
+                                        type="button"
+                                        className="self-start"
+                                        onClick={() =>
+                                            set_configuration(current => ({
+                                                ...current,
+                                                hamlib: { ...current.hamlib, rig2: empty_rig() },
+                                            }))
+                                        }
+                                    >
+                                        Add Rig 2
+                                    </button>
+                                ) : (
+                                    <>
+                                        <RigSettings
+                                            rig="rig2"
+                                            configuration={configuration}
+                                            models={hamlib_models}
+                                            descriptors={hamlib_model_details[rig2_model_id] || hamlib_model_detail}
+                                            error={
+                                                configuration_error?.field?.startsWith("hamlib.rig2")
+                                                    ? configuration_error
+                                                    : null
+                                            }
+                                            set_configuration={set_configuration}
+                                        />
+                                        <button
+                                            type="button"
+                                            className="self-start"
+                                            onClick={() =>
+                                                set_configuration(current => ({
+                                                    ...current,
+                                                    hamlib: { ...current.hamlib, rig2: null },
+                                                }))
+                                            }
+                                        >
+                                            Remove Rig 2
+                                        </button>
+                                    </>
+                                )}
+                            </>
+                        ) : null}
+                        {configuration_error != null ? (
+                            <p role="alert">{configuration_error.message}</p>
+                        ) : null}
+                        {radio_status === "disconnected" ? (
+                            <div className="flex items-center gap-2">
+                                <span>Radio disconnected</span>
+                                <button type="button" onClick={retry_radio}>
+                                    Retry
+                                </button>
+                                {radio_retry_result?.ok === false ? (
+                                    <span role="alert">{radio_retry_result.error?.message}</span>
+                                ) : null}
+                            </div>
+                        ) : null}
+                        <button
+                            type="button"
+                            className="self-start"
+                            disabled={configuration.backend === "hamlib" && !configuration.hamlib.rig1.model_id}
+                            onClick={apply_configuration}
+                        >
+                            Apply radio hardware
+                        </button>
+                    </section>
+                ) : null}
                 <table
                     className="table-fixed border-separate border-spacing-y-2"
                     style={{ color: colors.theme.text }}

--- a/ui/src/components/settings/CatControl.jsx
+++ b/ui/src/components/settings/CatControl.jsx
@@ -44,7 +44,11 @@ function DescriptorInput({ descriptor, value, on_change, error_token }) {
 
     if (descriptor.kind === "boolean") {
         return (
-            <label className="flex items-center gap-2" title={descriptor.tooltip} htmlFor={input_id}>
+            <label
+                className="flex items-center gap-2"
+                title={descriptor.tooltip}
+                htmlFor={input_id}
+            >
                 <input
                     id={input_id}
                     checked={value === "true"}
@@ -78,7 +82,11 @@ function DescriptorInput({ descriptor, value, on_change, error_token }) {
                     id={input_id}
                     aria-invalid={invalid}
                     className={input_class}
-                    type={descriptor.kind === "integer" || descriptor.kind === "numeric" ? "number" : "text"}
+                    type={
+                        descriptor.kind === "integer" || descriptor.kind === "numeric"
+                            ? "number"
+                            : "text"
+                    }
                     min={descriptor.minimum}
                     max={descriptor.maximum}
                     step={descriptor.step}
@@ -129,12 +137,18 @@ function RigSettings({ rig, configuration, models, descriptors, error, set_confi
                     key={descriptor.token}
                     descriptor={descriptor}
                     error_token={error?.token}
-                    value={rig_configuration.token_values[descriptor.token] ?? String(descriptor.default)}
+                    value={
+                        rig_configuration.token_values[descriptor.token] ??
+                        String(descriptor.default)
+                    }
                     on_change={value =>
                         set_configuration(current =>
                             update_rig(current, rig, current_rig => ({
                                 ...current_rig,
-                                token_values: { ...current_rig.token_values, [descriptor.token]: value },
+                                token_values: {
+                                    ...current_rig.token_values,
+                                    [descriptor.token]: value,
+                                },
                             })),
                         )
                     }
@@ -165,7 +179,8 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
     const [configuration, set_configuration] = useState(null);
 
     const configuration_capable = radio_capabilities?.radio_configuration === true;
-    const configuration_error = radio_configuration_result?.ok === false ? radio_configuration_result.error : null;
+    const configuration_error =
+        radio_configuration_result?.ok === false ? radio_configuration_result.error : null;
     const rig1_model_id = configuration?.hamlib?.rig1?.model_id;
     const rig2_model_id = configuration?.hamlib?.rig2?.model_id;
 
@@ -195,9 +210,7 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
         set_configuration(current => ({
             backend,
             hamlib:
-                backend === "hamlib"
-                    ? current?.hamlib || { rig1: empty_rig(), rig2: null }
-                    : null,
+                backend === "hamlib" ? current?.hamlib || { rig1: empty_rig(), rig2: null } : null,
         }));
     }
 
@@ -212,14 +225,19 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
         <>
             <div className="p-4" data-tour="settings-cat-control">
                 {configuration_capable && configuration != null ? (
-                    <section className="mb-6 flex flex-col gap-3" aria-label="Radio hardware settings">
+                    <section
+                        className="mb-6 flex flex-col gap-3"
+                        aria-label="Radio hardware settings"
+                    >
                         <h4 className="text-lg">Radio hardware</h4>
                         <label className="flex flex-col gap-1" htmlFor="radio-backend">
                             <span>Backend</span>
                             <Select
                                 id="radio-backend"
                                 value={configuration.backend}
-                                className={configuration_error?.field === "backend" ? "bg-red-200" : ""}
+                                className={
+                                    configuration_error?.field === "backend" ? "bg-red-200" : ""
+                                }
                                 onChange={event => select_backend(event.target.value)}
                             >
                                 {radio_capabilities.backends.map(backend => (
@@ -238,7 +256,9 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
                                     rig="rig1"
                                     configuration={configuration}
                                     models={hamlib_models}
-                                    descriptors={hamlib_model_details[rig1_model_id] || hamlib_model_detail}
+                                    descriptors={
+                                        hamlib_model_details[rig1_model_id] || hamlib_model_detail
+                                    }
                                     error={
                                         configuration_error?.field?.startsWith("hamlib.rig1")
                                             ? configuration_error
@@ -268,9 +288,13 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
                                             rig="rig2"
                                             configuration={configuration}
                                             models={hamlib_models}
-                                            descriptors={hamlib_model_details[rig2_model_id] || hamlib_model_detail}
+                                            descriptors={
+                                                hamlib_model_details[rig2_model_id] || hamlib_model_detail
+                                            }
                                             error={
-                                                configuration_error?.field?.startsWith("hamlib.rig2")
+                                                configuration_error?.field?.startsWith(
+                                                    "hamlib.rig2",
+                                                )
                                                     ? configuration_error
                                                     : null
                                             }
@@ -309,7 +333,10 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
                         <button
                             type="button"
                             className="self-start"
-                            disabled={configuration.backend === "hamlib" && !configuration.hamlib.rig1.model_id}
+                            disabled={
+                                configuration.backend === "hamlib" &&
+                                !configuration.hamlib.rig1.model_id
+                            }
                             onClick={apply_configuration}
                         >
                             Apply radio hardware

--- a/ui/src/components/settings/CatControl.jsx
+++ b/ui/src/components/settings/CatControl.jsx
@@ -289,7 +289,8 @@ function CatControl({ temp_settings, set_temp_settings, colors }) {
                                             configuration={configuration}
                                             models={hamlib_models}
                                             descriptors={
-                                                hamlib_model_details[rig2_model_id] || hamlib_model_detail
+                                                hamlib_model_details[rig2_model_id] ||
+                                                hamlib_model_detail
                                             }
                                             error={
                                                 configuration_error?.field?.startsWith(

--- a/ui/src/components/settings/Settings.jsx
+++ b/ui/src/components/settings/Settings.jsx
@@ -69,7 +69,7 @@ function Settings({ set_map_controls, set_radius_in_km }) {
     const { colors, setTheme } = useColors();
     const { settings, set_settings } = useSettings();
     const { setFilters, setProfileFilters, is_shared_filter_state } = useFilters();
-    const { is_radio_available } = use_radio();
+    const { get_radio_capabilities, is_radio_available, radio_status } = use_radio();
     const is_mobile_settings = useMediaQuery("only screen and (max-width : 768px)");
 
     useEffect(() => {
@@ -82,6 +82,12 @@ function Settings({ set_map_controls, set_radius_in_km }) {
         document.addEventListener(TOUR_SELECT_SETTINGS_TAB_EVENT, select_tab);
         return () => document.removeEventListener(TOUR_SELECT_SETTINGS_TAB_EVENT, select_tab);
     }, []);
+
+    useEffect(() => {
+        if (radio_status !== "unavailable" && is_radio_available()) {
+            get_radio_capabilities();
+        }
+    }, [radio_status]);
 
     function disable_settings_filters(current_filters, new_settings) {
         const updated_bands = { ...current_filters.bands };

--- a/ui/src/hooks/useRadio.jsx
+++ b/ui/src/hooks/useRadio.jsx
@@ -129,7 +129,10 @@ export function RadioProvider({ children }) {
         if (data.event === "hamlib_model" && requested_model_ids.current.has(data.model_id)) {
             set_hamlib_model_detail(data.descriptors || null);
             if (data.descriptors != null) {
-                set_hamlib_model_details(current => ({ ...current, [data.model_id]: data.descriptors }));
+                set_hamlib_model_details(current => ({
+                    ...current,
+                    [data.model_id]: data.descriptors,
+                }));
             }
             set_hamlib_model_error(data.error || null);
         }

--- a/ui/src/hooks/useRadio.jsx
+++ b/ui/src/hooks/useRadio.jsx
@@ -84,11 +84,12 @@ export function RadioProvider({ children }) {
     const [hamlib_models, set_hamlib_models] = useState([]);
     const [hamlib_models_error, set_hamlib_models_error] = useState(null);
     const [hamlib_model_detail, set_hamlib_model_detail] = useState(null);
+    const [hamlib_model_details, set_hamlib_model_details] = useState({});
     const [hamlib_model_error, set_hamlib_model_error] = useState(null);
     const [radio_configuration, set_radio_configuration_state] = useState(null);
     const [radio_configuration_result, set_radio_configuration_result] = useState(null);
     const [radio_retry_result, set_radio_retry_result] = useState(null);
-    const requested_model_id = useRef(null);
+    const requested_model_ids = useRef(new Set());
     const pending_configuration_action = useRef(null);
 
     const { settings } = useSettings();
@@ -125,8 +126,11 @@ export function RadioProvider({ children }) {
             set_hamlib_models_error(data.error || null);
         }
 
-        if (data.event === "hamlib_model" && data.model_id === requested_model_id.current) {
+        if (data.event === "hamlib_model" && requested_model_ids.current.has(data.model_id)) {
             set_hamlib_model_detail(data.descriptors || null);
+            if (data.descriptors != null) {
+                set_hamlib_model_details(current => ({ ...current, [data.model_id]: data.descriptors }));
+            }
             set_hamlib_model_error(data.error || null);
         }
 
@@ -210,7 +214,7 @@ export function RadioProvider({ children }) {
     }
 
     function describe_hamlib_model(model_id) {
-        requested_model_id.current = model_id;
+        requested_model_ids.current.add(model_id);
         set_hamlib_model_detail(null);
         set_hamlib_model_error(null);
         send_message_to_radio({ action: "DescribeHamlibModel", model_id });
@@ -255,6 +259,7 @@ export function RadioProvider({ children }) {
                 hamlib_models,
                 hamlib_models_error,
                 hamlib_model_detail,
+                hamlib_model_details,
                 hamlib_model_error,
                 radio_configuration,
                 radio_configuration_result,

--- a/ui/tests/cat_control.jsx
+++ b/ui/tests/cat_control.jsx
@@ -29,6 +29,7 @@ const descriptors = [
         maximum: 115200,
         step: 1200,
     },
+    { kind: "text", token: "unsupported", label: "Unsupported", tooltip: "", default: "" },
 ];
 
 function configuration(
@@ -81,12 +82,13 @@ describe("CAT control settings", () => {
         await user.selectOptions(screen.getByLabelText("Rig"), "rig2");
         await user.click(screen.getByLabelText("Enable Rig 2"));
         await user.selectOptions(screen.getByLabelText("Backend"), "hamlib");
-        await user.type(screen.getByRole("combobox", { name: "Model" }), "2");
+        await user.selectOptions(screen.getByLabelText("Model"), "2");
         expect(screen.getByLabelText("Serial port")).not.toBeNull();
+        expect(screen.queryByLabelText("Unsupported")).toBeNull();
         await user.selectOptions(screen.getByLabelText("Rig"), "rig1");
         expect(screen.getByLabelText("Host").value).toBe("rig-one");
         await user.selectOptions(screen.getByLabelText("Rig"), "rig2");
-        expect(screen.getByRole("combobox", { name: "Model" }).value).toBe("2");
+        expect(screen.getByLabelText("Model").value).toBe("2");
     });
 
     it("serializes only active backend payloads", async () => {

--- a/ui/tests/cat_control.jsx
+++ b/ui/tests/cat_control.jsx
@@ -18,8 +18,7 @@ import CatControl from "@/components/settings/CatControl.jsx";
 
 const colors = { theme: { text: "black" } };
 const descriptors = [
-    { kind: "text", token: "device", label: "Device", tooltip: "", default: "" },
-    { kind: "path", token: "path", label: "Path", tooltip: "", default: "" },
+    { kind: "text", token: "rig_pathname", label: "Pathname", tooltip: "", default: "" },
     {
         kind: "integer",
         token: "baud",
@@ -30,19 +29,13 @@ const descriptors = [
         maximum: 115200,
         step: 1200,
     },
-    { kind: "boolean", token: "rts", label: "RTS", tooltip: "", default: false },
-    {
-        kind: "combo",
-        token: "parity",
-        label: "Parity",
-        tooltip: "",
-        default: "none",
-        options: ["none", "even"],
-    },
 ];
 
-function configuration(hamlib = null) {
-    return { event: "configuration", backend: hamlib == null ? "omnirig" : "hamlib", hamlib };
+function configuration(
+    rig1 = { backend: "rigctld", rigctld: { host: "127.0.0.1", port: 4532 } },
+    rig2 = undefined,
+) {
+    return { event: "configuration", rig1, ...(rig2 ? { rig2 } : {}) };
 }
 
 function render_cat() {
@@ -58,91 +51,78 @@ function render_cat() {
 describe("CAT control settings", () => {
     beforeEach(() => {
         radio.current = {
-            radio_capabilities: { radio_configuration: true, backends: ["omnirig", "hamlib"] },
+            radio_capabilities: { radio_configuration: true, backends: ["rigctld", "hamlib"] },
             radio_configuration: configuration(),
             radio_configuration_result: null,
-            radio_retry_result: null,
-            radio_status: "connected",
-            hamlib_models: [
-                { id: "2", manufacturer: "Acme", model: "Rig", version: "", status: "stable" },
-            ],
+            hamlib_models: [{ id: "2", manufacturer: "Acme", model: "Rig" }],
             hamlib_models_error: null,
-            hamlib_model_detail: descriptors,
             hamlib_model_details: { 2: descriptors },
             hamlib_model_error: null,
             get_radio_configuration: vi.fn(),
             list_hamlib_models: vi.fn(),
             describe_hamlib_model: vi.fn(),
             set_radio_configuration: vi.fn(),
-            retry_radio: vi.fn(),
         };
     });
-
     afterEach(() => cleanup());
 
-    it("shows capable disconnected controls and retries the radio", async () => {
-        const user = userEvent.setup();
-        radio.current.radio_status = "disconnected";
+    it("always provides a native Rig 1 and Rig 2 selector", () => {
         render_cat();
-
-        expect(screen.getByRole("heading", { name: "Radio hardware" })).not.toBeNull();
-        expect(screen.getByText("Radio disconnected")).not.toBeNull();
-        await user.click(screen.getByRole("button", { name: "Retry" }));
-
-        expect(radio.current.retry_radio).toHaveBeenCalledOnce();
+        expect(screen.getByLabelText("Rig").tagName).toBe("SELECT");
+        expect(screen.getByRole("option", { name: "Rig 1" })).not.toBeNull();
+        expect(screen.getByRole("option", { name: "Rig 2" })).not.toBeNull();
     });
 
-    it("requires Rig 1 before applying Hamlib settings", async () => {
+    it("preserves independent rig drafts while switching rigs and backends", async () => {
         const user = userEvent.setup();
         render_cat();
-
+        await user.clear(screen.getByLabelText("Host"));
+        await user.type(screen.getByLabelText("Host"), "rig-one");
+        await user.selectOptions(screen.getByLabelText("Rig"), "rig2");
+        await user.click(screen.getByLabelText("Enable Rig 2"));
         await user.selectOptions(screen.getByLabelText("Backend"), "hamlib");
-
-        expect(screen.getByRole("button", { name: "Apply radio hardware" }).disabled).toBe(true);
+        await user.type(screen.getByRole("combobox", { name: "Model" }), "2");
+        expect(screen.getByLabelText("Serial port")).not.toBeNull();
+        await user.selectOptions(screen.getByLabelText("Rig"), "rig1");
+        expect(screen.getByLabelText("Host").value).toBe("rig-one");
+        await user.selectOptions(screen.getByLabelText("Rig"), "rig2");
+        expect(screen.getByRole("combobox", { name: "Model" }).value).toBe("2");
     });
 
-    it("renders descriptor inputs and supports an optional second rig", async () => {
+    it("serializes only active backend payloads", async () => {
         const user = userEvent.setup();
-        radio.current.radio_configuration = configuration({
-            rig1: { model_id: "2", token_values: {} },
-            rig2: null,
-        });
         render_cat();
-
-        expect(screen.getByLabelText("Device")).not.toBeNull();
-        expect(screen.getByLabelText("Path")).not.toBeNull();
-        expect(screen.getByLabelText("Baud")).not.toBeNull();
-        expect(screen.getByLabelText("RTS")).not.toBeNull();
-        expect(screen.getByLabelText("Parity")).not.toBeNull();
-        await user.click(screen.getByRole("button", { name: "Add Rig 2" }));
-
-        expect(screen.getByText("Rig 2")).not.toBeNull();
-        expect(screen.getByRole("button", { name: "Remove Rig 2" })).not.toBeNull();
+        await user.click(screen.getByRole("button", { name: "Save radio hardware" }));
+        expect(radio.current.set_radio_configuration).toHaveBeenCalledWith({
+            rig1: { backend: "rigctld", rigctld: { host: "127.0.0.1", port: 4532 } },
+        });
     });
 
-    it("surfaces server field and token errors", () => {
-        radio.current.radio_configuration = configuration({
-            rig1: { model_id: "2", token_values: {} },
-            rig2: null,
-        });
+    it("shows a successful radio hardware save result", async () => {
+        radio.current.radio_configuration_result = { ok: true };
+        render_cat();
+        expect((await screen.findByRole("status")).textContent).toContain("Radio hardware saved.");
+    });
+
+    it("validates rigctld ports on blur and scopes server errors to the selected rig", async () => {
+        const user = userEvent.setup();
         radio.current.radio_configuration_result = {
             ok: false,
-            error: {
-                field: "hamlib.rig1.token_values",
-                token: "device",
-                message: "Invalid device",
-            },
+            error: { field: "rig2.rigctld.port", message: "Invalid Rig 2 port" },
         };
         render_cat();
-
-        expect(screen.getByRole("alert").textContent).toContain("Invalid device");
-        expect(screen.getByLabelText("Device").getAttribute("aria-invalid")).toBe("true");
+        expect(screen.queryByText("Invalid Rig 2 port")).toBeNull();
+        await user.clear(screen.getByLabelText("Port"));
+        await user.tab();
+        expect(screen.getByLabelText("Port").getAttribute("aria-invalid")).toBeNull();
+        expect(screen.getByLabelText("Port").className).toContain("bg-red-200");
+        await user.selectOptions(screen.getByLabelText("Rig"), "rig2");
+        expect(screen.getByRole("alert").textContent).toContain("Invalid Rig 2 port");
     });
 
     it("keeps logger integration available for legacy CAT servers", () => {
         radio.current.radio_capabilities = null;
         render_cat();
-
         expect(screen.queryByRole("heading", { name: "Radio hardware" })).toBeNull();
         expect(screen.getByText("Enable logger integration:")).not.toBeNull();
         expect(radio.current.get_radio_configuration).not.toHaveBeenCalled();

--- a/ui/tests/cat_control.jsx
+++ b/ui/tests/cat_control.jsx
@@ -1,0 +1,132 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const radio = vi.hoisted(() => ({ current: null }));
+
+vi.mock("@/hooks/useRadio", () => ({ default: () => radio.current }));
+vi.mock("@/hooks/useColors", () => ({
+    useColors: () => ({ theme: { input_background: "white", text: "black", disabled_text: "gray" } }),
+}));
+
+import CatControl from "@/components/settings/CatControl.jsx";
+
+const colors = { theme: { text: "black" } };
+const descriptors = [
+    { kind: "text", token: "device", label: "Device", tooltip: "", default: "" },
+    { kind: "path", token: "path", label: "Path", tooltip: "", default: "" },
+    {
+        kind: "integer",
+        token: "baud",
+        label: "Baud",
+        tooltip: "",
+        default: 9600,
+        minimum: 1200,
+        maximum: 115200,
+        step: 1200,
+    },
+    { kind: "boolean", token: "rts", label: "RTS", tooltip: "", default: false },
+    { kind: "combo", token: "parity", label: "Parity", tooltip: "", default: "none", options: ["none", "even"] },
+];
+
+function configuration(hamlib = null) {
+    return { event: "configuration", backend: hamlib == null ? "omnirig" : "hamlib", hamlib };
+}
+
+function render_cat() {
+    return render(
+        <CatControl
+            temp_settings={{ highlight_enabled: true, highlight_port: 2237 }}
+            set_temp_settings={vi.fn()}
+            colors={colors}
+        />,
+    );
+}
+
+describe("CAT control settings", () => {
+    beforeEach(() => {
+        radio.current = {
+            radio_capabilities: { radio_configuration: true, backends: ["omnirig", "hamlib"] },
+            radio_configuration: configuration(),
+            radio_configuration_result: null,
+            radio_retry_result: null,
+            radio_status: "connected",
+            hamlib_models: [{ id: "2", manufacturer: "Acme", model: "Rig", version: "", status: "stable" }],
+            hamlib_models_error: null,
+            hamlib_model_detail: descriptors,
+            hamlib_model_details: { "2": descriptors },
+            hamlib_model_error: null,
+            get_radio_configuration: vi.fn(),
+            list_hamlib_models: vi.fn(),
+            describe_hamlib_model: vi.fn(),
+            set_radio_configuration: vi.fn(),
+            retry_radio: vi.fn(),
+        };
+    });
+
+    afterEach(() => cleanup());
+
+    it("shows capable disconnected controls and retries the radio", async () => {
+        const user = userEvent.setup();
+        radio.current.radio_status = "disconnected";
+        render_cat();
+
+        expect(screen.getByRole("heading", { name: "Radio hardware" })).not.toBeNull();
+        expect(screen.getByText("Radio disconnected")).not.toBeNull();
+        await user.click(screen.getByRole("button", { name: "Retry" }));
+
+        expect(radio.current.retry_radio).toHaveBeenCalledOnce();
+    });
+
+    it("requires Rig 1 before applying Hamlib settings", async () => {
+        const user = userEvent.setup();
+        render_cat();
+
+        await user.selectOptions(screen.getByLabelText("Backend"), "hamlib");
+
+        expect(screen.getByRole("button", { name: "Apply radio hardware" })).toBeDisabled();
+    });
+
+    it("renders descriptor inputs and supports an optional second rig", async () => {
+        const user = userEvent.setup();
+        radio.current.radio_configuration = configuration({
+            rig1: { model_id: "2", token_values: {} },
+            rig2: null,
+        });
+        render_cat();
+
+        expect(screen.getByLabelText("Device")).not.toBeNull();
+        expect(screen.getByLabelText("Path")).not.toBeNull();
+        expect(screen.getByLabelText("Baud")).not.toBeNull();
+        expect(screen.getByLabelText("RTS")).not.toBeNull();
+        expect(screen.getByLabelText("Parity")).not.toBeNull();
+        await user.click(screen.getByRole("button", { name: "Add Rig 2" }));
+
+        expect(screen.getByText("Rig 2")).not.toBeNull();
+        expect(screen.getByRole("button", { name: "Remove Rig 2" })).not.toBeNull();
+    });
+
+    it("surfaces server field and token errors", () => {
+        radio.current.radio_configuration = configuration({
+            rig1: { model_id: "2", token_values: {} },
+            rig2: null,
+        });
+        radio.current.radio_configuration_result = {
+            ok: false,
+            error: { field: "hamlib.rig1.token_values", token: "device", message: "Invalid device" },
+        };
+        render_cat();
+
+        expect(screen.getByRole("alert")).toHaveTextContent("Invalid device");
+        expect(screen.getByLabelText("Device")).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("keeps logger integration available for legacy CAT servers", () => {
+        radio.current.radio_capabilities = null;
+        render_cat();
+
+        expect(screen.queryByRole("heading", { name: "Radio hardware" })).toBeNull();
+        expect(screen.getByText("Enable logger integration:")).not.toBeNull();
+        expect(radio.current.get_radio_configuration).not.toHaveBeenCalled();
+    });
+});

--- a/ui/tests/cat_control.jsx
+++ b/ui/tests/cat_control.jsx
@@ -7,7 +7,10 @@ const radio = vi.hoisted(() => ({ current: null }));
 vi.mock("@/hooks/useRadio", () => ({ default: () => radio.current }));
 vi.mock("@/hooks/useColors", () => ({
     useColors: () => ({
-        theme: { input_background: "white", text: "black", disabled_text: "gray" },
+        colors: {
+            theme: { input_background: "white", text: "black", disabled_text: "gray" },
+            buttons: { utility: "black" },
+        },
     }),
 }));
 
@@ -95,7 +98,7 @@ describe("CAT control settings", () => {
 
         await user.selectOptions(screen.getByLabelText("Backend"), "hamlib");
 
-        expect(screen.getByRole("button", { name: "Apply radio hardware" })).toBeDisabled();
+        expect(screen.getByRole("button", { name: "Apply radio hardware" }).disabled).toBe(true);
     });
 
     it("renders descriptor inputs and supports an optional second rig", async () => {
@@ -132,8 +135,8 @@ describe("CAT control settings", () => {
         };
         render_cat();
 
-        expect(screen.getByRole("alert")).toHaveTextContent("Invalid device");
-        expect(screen.getByLabelText("Device")).toHaveAttribute("aria-invalid", "true");
+        expect(screen.getByRole("alert").textContent).toContain("Invalid device");
+        expect(screen.getByLabelText("Device").getAttribute("aria-invalid")).toBe("true");
     });
 
     it("keeps logger integration available for legacy CAT servers", () => {

--- a/ui/tests/cat_control.jsx
+++ b/ui/tests/cat_control.jsx
@@ -6,7 +6,9 @@ const radio = vi.hoisted(() => ({ current: null }));
 
 vi.mock("@/hooks/useRadio", () => ({ default: () => radio.current }));
 vi.mock("@/hooks/useColors", () => ({
-    useColors: () => ({ theme: { input_background: "white", text: "black", disabled_text: "gray" } }),
+    useColors: () => ({
+        theme: { input_background: "white", text: "black", disabled_text: "gray" },
+    }),
 }));
 
 import CatControl from "@/components/settings/CatControl.jsx";
@@ -26,7 +28,14 @@ const descriptors = [
         step: 1200,
     },
     { kind: "boolean", token: "rts", label: "RTS", tooltip: "", default: false },
-    { kind: "combo", token: "parity", label: "Parity", tooltip: "", default: "none", options: ["none", "even"] },
+    {
+        kind: "combo",
+        token: "parity",
+        label: "Parity",
+        tooltip: "",
+        default: "none",
+        options: ["none", "even"],
+    },
 ];
 
 function configuration(hamlib = null) {
@@ -51,10 +60,12 @@ describe("CAT control settings", () => {
             radio_configuration_result: null,
             radio_retry_result: null,
             radio_status: "connected",
-            hamlib_models: [{ id: "2", manufacturer: "Acme", model: "Rig", version: "", status: "stable" }],
+            hamlib_models: [
+                { id: "2", manufacturer: "Acme", model: "Rig", version: "", status: "stable" },
+            ],
             hamlib_models_error: null,
             hamlib_model_detail: descriptors,
-            hamlib_model_details: { "2": descriptors },
+            hamlib_model_details: { 2: descriptors },
             hamlib_model_error: null,
             get_radio_configuration: vi.fn(),
             list_hamlib_models: vi.fn(),
@@ -113,7 +124,11 @@ describe("CAT control settings", () => {
         });
         radio.current.radio_configuration_result = {
             ok: false,
-            error: { field: "hamlib.rig1.token_values", token: "device", message: "Invalid device" },
+            error: {
+                field: "hamlib.rig1.token_values",
+                token: "device",
+                message: "Invalid device",
+            },
         };
         render_cat();
 


### PR DESCRIPTION
## Summary
- add CAT-server-local backend, Hamlib model, rig, and descriptor controls
- expose configuration errors and disconnected retry state while preserving legacy logger settings
- add focused CAT settings UI coverage

## Tests
- Not run (requested)

## Risks
- Final verification intentionally deferred per request.