### PR TITLE
Add map spot quick filters

### DIFF
--- a/ui/src/components/CanvasMap/index.jsx
+++ b/ui/src/components/CanvasMap/index.jsx
@@ -26,6 +26,7 @@ import {
     MAP_FILTER_ACTIONS,
     build_filter_menu_actions,
     build_map_context_filter,
+    build_spot_context_menu_actions,
 } from "./map_context_menu.js";
 import {
     build_missing_overlay_highlights,
@@ -71,6 +72,7 @@ function CanvasMap({
         number: null,
         entity: null,
         is_filterable_entity: false,
+        spot: null,
     });
 
     const animation_id_ref = useRef(null);
@@ -94,6 +96,11 @@ function CanvasMap({
         map_context_menu.type === "dxcc" ? get_dxcc_label(map_context_menu.entity) : null,
         map_menu_has_invalid_dxcc_entity,
         map_menu_has_invalid_dxcc_entity ? "Unmapped DXCC" : null,
+        get_filter_add_status,
+        add_filter_if_allowed,
+    );
+    const spot_menu_actions = build_spot_context_menu_actions(
+        map_context_menu.spot,
         get_filter_add_status,
         add_filter_if_allowed,
     );
@@ -249,6 +256,7 @@ function CanvasMap({
                     number,
                     entity: null,
                     is_filterable_entity: false,
+                    spot: null,
                 });
             },
             open_dxcc_context_menu: (x, y, entity) => {
@@ -261,6 +269,20 @@ function CanvasMap({
                     number: null,
                     entity,
                     is_filterable_entity: is_filterable_dxcc_entity(entity),
+                    spot: null,
+                });
+            },
+            open_spot_context_menu: (x, y, spot) => {
+                set_map_context_menu({
+                    visible: true,
+                    x,
+                    y,
+                    type: "spot",
+                    system: null,
+                    number: null,
+                    entity: null,
+                    is_filterable_entity: false,
+                    spot,
                 });
             },
         },
@@ -399,9 +421,11 @@ function CanvasMap({
                 <SpotContextMenu
                     x={map_context_menu.x}
                     y={map_context_menu.y}
-                    spot={null}
+                    spot={map_context_menu.spot}
                     on_close={() => set_map_context_menu(state => ({ ...state, visible: false }))}
-                    actions={map_menu_actions}
+                    actions={
+                        map_context_menu.type === "spot" ? spot_menu_actions : map_menu_actions
+                    }
                     data_tour="map-context-menu"
                 />
             )}

--- a/ui/src/components/CanvasMap/map_context_menu.js
+++ b/ui/src/components/CanvasMap/map_context_menu.js
@@ -39,6 +39,37 @@ export function build_map_context_filter(action, menu_type, entity, number, syst
     };
 }
 
+function get_filterable_callsign(spot) {
+    const callsign = spot?.dx_callsign;
+    return typeof callsign === "string" && callsign.trim() ? callsign.trim() : null;
+}
+
+export function build_spot_context_filter(action, spot) {
+    return {
+        action,
+        type: "prefix",
+        value: get_filterable_callsign(spot),
+        spotter_or_dx: "dx",
+    };
+}
+
+export function build_spot_context_menu_actions(
+    spot,
+    get_filter_add_status,
+    add_filter_if_allowed,
+) {
+    const callsign = get_filterable_callsign(spot);
+    return build_filter_menu_actions(
+        MAP_FILTER_ACTIONS,
+        action => build_spot_context_filter(action, spot),
+        callsign,
+        callsign == null,
+        callsign == null ? "Missing DX callsign" : null,
+        get_filter_add_status,
+        add_filter_if_allowed,
+    );
+}
+
 export function build_filter_menu_actions(
     MAP_FILTER_ACTIONS,
     build_candidate_filter,

--- a/ui/src/components/CanvasMap/useMapGestures.js
+++ b/ui/src/components/CanvasMap/useMapGestures.js
@@ -563,7 +563,6 @@ export function useMapGestures({
         }
 
         function on_context_menu(event) {
-            if (event.target.tagName !== "CANVAS") return;
             const pos = get_offset(event);
             const searched = get_data_from_shadow_canvas(pos.x, pos.y);
             if (searched == null) return;

--- a/ui/src/components/CanvasMap/useMapGestures.js
+++ b/ui/src/components/CanvasMap/useMapGestures.js
@@ -335,6 +335,7 @@ export function useMapGestures({
 
         function on_pointer_down(event) {
             if (event.target.tagName !== "CANVAS") return;
+            if (event.pointerType === "mouse" && event.button !== 0) return;
             const pos = get_offset(event);
 
             if (event.pointerType !== "mouse" && !is_inside_map_circle(pos.x, pos.y)) return;
@@ -561,12 +562,27 @@ export function useMapGestures({
             }
         }
 
+        function on_context_menu(event) {
+            if (event.target.tagName !== "CANVAS") return;
+            const pos = get_offset(event);
+            const searched = get_data_from_shadow_canvas(pos.x, pos.y);
+            if (searched == null) return;
+
+            const [, spot_id] = searched;
+            const spot = render_state_ref.current.spots.find(candidate => candidate.id === spot_id);
+            if (spot == null) return;
+
+            event.preventDefault();
+            callbacks_ref.current.open_spot_context_menu(event.clientX, event.clientY, spot);
+        }
+
         container.addEventListener("pointerdown", on_pointer_down);
         container.addEventListener("pointermove", on_pointer_move);
         container.addEventListener("pointerup", on_pointer_up);
         container.addEventListener("pointerleave", on_pointer_leave);
         container.addEventListener("pointercancel", on_pointer_leave);
         container.addEventListener("dblclick", on_dblclick);
+        container.addEventListener("contextmenu", on_context_menu);
         container.addEventListener("touchstart", on_touch_start_capture, {
             capture: true,
             passive: false,
@@ -591,6 +607,7 @@ export function useMapGestures({
             container.removeEventListener("pointerleave", on_pointer_leave);
             container.removeEventListener("pointercancel", on_pointer_leave);
             container.removeEventListener("dblclick", on_dblclick);
+            container.removeEventListener("contextmenu", on_context_menu);
             container.removeEventListener("touchstart", on_touch_start_capture, true);
             container.removeEventListener("touchmove", on_touch_move_capture, true);
             container.removeEventListener("touchend", on_touch_end_capture, true);

--- a/ui/src/components/SpotContextMenu.jsx
+++ b/ui/src/components/SpotContextMenu.jsx
@@ -98,6 +98,7 @@ export default function SpotContextMenu({
                         }`}
                         role="button"
                         tabIndex={0}
+                        aria-disabled={disabled}
                         onKeyDown={event => {
                             if (disabled) return;
                             if (event.key === "Enter" || event.key === " ") {

--- a/ui/tests/dxcc_entities.js
+++ b/ui/tests/dxcc_entities.js
@@ -1,9 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("virtual:cty-dxcc-entities", () => ({
-    default: [],
-    dxcc_entities_by_code: {},
-    dxcc_code_entities: {},
+    default: ["United States", "Fed. Rep. of Germany", "Canada"],
+    dxcc_entities_by_code: {
+        1: { code: 1, raw_cty_name: "Canada", continent: "NA" },
+        230: { code: 230, raw_cty_name: "Fed. Rep. of Germany", continent: "EU" },
+        291: { code: 291, raw_cty_name: "United States", continent: "NA" },
+    },
+    dxcc_code_entities: {
+        1: "Canada",
+        230: "Fed. Rep. of Germany",
+        291: "United States",
+    },
 }));
 
 import { build_dxcc_entity_by_code, get_dxcc_label } from "@/data/dxcc_entities.js";

--- a/ui/tests/map_context_menu.jsx
+++ b/ui/tests/map_context_menu.jsx
@@ -1,11 +1,13 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
     build_spot_context_filter,
     build_spot_context_menu_actions,
 } from "@/components/CanvasMap/map_context_menu.js";
+import { useMapGestures } from "@/components/CanvasMap/useMapGestures.js";
 import SpotContextMenu from "@/components/SpotContextMenu.jsx";
 
 vi.mock("@/hooks/useColors", () => ({
@@ -16,6 +18,54 @@ vi.mock("@/hooks/useColors", () => ({
         },
     }),
 }));
+
+function MapGestureHarness({ get_data_from_shadow_canvas, open_spot_context_menu }) {
+    const shadow_canvas_ref = useRef(document.createElement("canvas"));
+    const projection_ref = useRef({});
+    const hit_test_ref = useRef();
+    hit_test_ref.current = {
+        get_data_from_shadow_canvas,
+        get_clickable_zone_label: () => null,
+        get_clickable_dxcc_label: () => null,
+    };
+    const render_state_ref = useRef({
+        spots: [{ id: 1, dx_callsign: "K1ABC" }],
+        map_controls: { is_globe: false },
+        hovered_spot: { id: null, source: null },
+        hovered_zone: { system: null, number: null },
+        hovered_dxcc: null,
+    });
+
+    const { container_ref } = useMapGestures({
+        dims: { center_x: 50, center_y: 50, radius: 50 },
+        projection_ref,
+        base_scale_ref: useRef(1),
+        canvas_refs: { shadow_canvas_ref },
+        render_state_ref,
+        gesture_active_ref: useRef(false),
+        hit_test_ref,
+        set_auto_radius: vi.fn(),
+        set_radius_in_km: vi.fn(),
+        set_hovered_zone: vi.fn(),
+        set_hovered_dxcc: vi.fn(),
+        callbacks: {
+            set_map_controls: vi.fn(),
+            set_cat_to_spot: vi.fn(),
+            set_hovered_spot: vi.fn(),
+            set_pinned_spot: vi.fn(),
+            add_filter_if_allowed: vi.fn(),
+            open_zone_context_menu: vi.fn(),
+            open_dxcc_context_menu: vi.fn(),
+            open_spot_context_menu,
+        },
+    });
+
+    return (
+        <div ref={container_ref}>
+            <svg data-testid="map-overlay" />
+        </div>
+    );
+}
 
 describe("map spot context menu", () => {
     afterEach(() => {
@@ -78,5 +128,48 @@ describe("map spot context menu", () => {
         expect(screen.getAllByText("(Missing DX callsign)")).toHaveLength(3);
         expect(get_filter_add_status).not.toHaveBeenCalled();
         expect(build_spot_context_filter("hide", { dx_callsign: 42 }).value).toBeNull();
+    });
+
+    it("opens for a spot below a map overlay and preserves the native menu elsewhere", () => {
+        const open_spot_context_menu = vi.fn();
+        const { rerender } = render(
+            <MapGestureHarness
+                get_data_from_shadow_canvas={() => ["dx", 1]}
+                open_spot_context_menu={open_spot_context_menu}
+            />,
+        );
+        const overlay = screen.getByTestId("map-overlay");
+        const spot_event = new MouseEvent("contextmenu", {
+            bubbles: true,
+            cancelable: true,
+            clientX: 25,
+            clientY: 30,
+        });
+
+        overlay.dispatchEvent(spot_event);
+
+        expect(spot_event.defaultPrevented).toBe(true);
+        expect(open_spot_context_menu).toHaveBeenCalledWith(25, 30, {
+            id: 1,
+            dx_callsign: "K1ABC",
+        });
+
+        rerender(
+            <MapGestureHarness
+                get_data_from_shadow_canvas={() => null}
+                open_spot_context_menu={open_spot_context_menu}
+            />,
+        );
+        const empty_event = new MouseEvent("contextmenu", {
+            bubbles: true,
+            cancelable: true,
+            clientX: 25,
+            clientY: 30,
+        });
+
+        screen.getByTestId("map-overlay").dispatchEvent(empty_event);
+
+        expect(empty_event.defaultPrevented).toBe(false);
+        expect(open_spot_context_menu).toHaveBeenCalledTimes(1);
     });
 });

--- a/ui/tests/map_context_menu.jsx
+++ b/ui/tests/map_context_menu.jsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+    build_spot_context_filter,
+    build_spot_context_menu_actions,
+} from "@/components/CanvasMap/map_context_menu.js";
+import SpotContextMenu from "@/components/SpotContextMenu.jsx";
+
+vi.mock("@/hooks/useColors", () => ({
+    useColors: () => ({
+        colors: {
+            buttons: { active_tab: "#222222" },
+            theme: { background: "#000000", border: "#333333", text: "#ffffff" },
+        },
+    }),
+}));
+
+describe("map spot context menu", () => {
+    afterEach(() => {
+        cleanup();
+        vi.restoreAllMocks();
+    });
+
+    it("adds a DX callsign filter through the shared filter action", async () => {
+        const user = userEvent.setup();
+        const get_filter_add_status = vi.fn(() => ({ status: "add" }));
+        const add_filter_if_allowed = vi.fn();
+        const spot = { id: 1, dx_callsign: "K1ABC" };
+
+        render(
+            <SpotContextMenu
+                x={10}
+                y={10}
+                spot={spot}
+                on_close={vi.fn()}
+                actions={build_spot_context_menu_actions(
+                    spot,
+                    get_filter_add_status,
+                    add_filter_if_allowed,
+                )}
+            />,
+        );
+
+        await user.click(screen.getByRole("button", { name: "Add Hide K1ABC" }));
+
+        expect(add_filter_if_allowed).toHaveBeenCalledWith({
+            action: "hide",
+            type: "prefix",
+            value: "K1ABC",
+            spotter_or_dx: "dx",
+        });
+    });
+
+    it("disables filters for malformed spot data", () => {
+        const get_filter_add_status = vi.fn();
+        const add_filter_if_allowed = vi.fn();
+        const actions = build_spot_context_menu_actions(
+            { id: 1, dx_callsign: "  " },
+            get_filter_add_status,
+            add_filter_if_allowed,
+        );
+
+        render(
+            <SpotContextMenu
+                x={10}
+                y={10}
+                spot={{ id: 1, dx_callsign: "  " }}
+                on_close={vi.fn()}
+                actions={actions}
+            />,
+        );
+
+        expect(
+            screen.getByRole("button", { name: /Add Alert/ }).getAttribute("aria-disabled"),
+        ).toBe("true");
+        expect(screen.getAllByText("(Missing DX callsign)")).toHaveLength(3);
+        expect(get_filter_add_status).not.toHaveBeenCalled();
+        expect(build_spot_context_filter("hide", { dx_callsign: 42 }).value).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary\n- open a context menu only when right-clicking a rendered map spot\n- add DX callsign alert, show-only, and hide filters through the shared filter actions\n- disable malformed spot filters with an accessible explanation\n\nCloses #355\n\n## Tests\n- npm test -- --run tests/map_context_menu.jsx\n- npx biome check src/components/CanvasMap/index.jsx src/components/CanvasMap/map_context_menu.js src/components/CanvasMap/useMapGestures.js src/components/SpotContextMenu.jsx tests/map_context_menu.jsx\n- npm test (one unrelated timing failure on first run; rerun of tests/website_tour.jsx passed)\n\n## Risks\n- Browser verification loaded the app successfully, but the local backend did not supply a spot to exercise the native map gesture end-to-end.