### PR TITLE
Add LoTW status to spots table

### DIFF
--- a/ui/src/components/SpotsTable.jsx
+++ b/ui/src/components/SpotsTable.jsx
@@ -163,16 +163,18 @@ export function get_lotw_status_details(status) {
 }
 
 export function LoTWStatus({ status }) {
+    if (status === "non_user") return null;
+
     const { label, symbol, className } = get_lotw_status_details(status);
 
     return (
         <span
-            className={`inline-block rounded-full px-1 text-xs leading-4 whitespace-nowrap ${className}`}
+            className={`inline-flex size-3 items-center justify-center rounded-full text-[9px] leading-none ${className}`}
             role="img"
             aria-label={label}
             title={label}
         >
-            LoTW {symbol}
+            {symbol}
         </span>
     );
 }

--- a/ui/src/components/SpotsTable.jsx
+++ b/ui/src/components/SpotsTable.jsx
@@ -134,6 +134,49 @@ const columns = [
     { title: "Comment", field: "comment", sorting: false },
 ];
 
+const lotw_status_details = {
+    frequent: {
+        label: "LoTW: active (last upload within 180 days)",
+        symbol: "✓",
+        className: "bg-emerald-700 text-white",
+    },
+    infrequent: {
+        label: "LoTW: user, last upload over 180 days ago",
+        symbol: "~",
+        className: "bg-amber-500 text-slate-950",
+    },
+    non_user: {
+        label: "LoTW: no user activity found",
+        symbol: "—",
+        className: "bg-slate-500 text-white",
+    },
+};
+
+export function get_lotw_status_details(status) {
+    return (
+        lotw_status_details[status] ?? {
+            label: "LoTW status unavailable",
+            symbol: "?",
+            className: "bg-slate-400 text-slate-950",
+        }
+    );
+}
+
+export function LoTWStatus({ status }) {
+    const { label, symbol, className } = get_lotw_status_details(status);
+
+    return (
+        <span
+            className={`inline-block rounded-full px-1 text-xs leading-4 whitespace-nowrap ${className}`}
+            role="img"
+            aria-label={label}
+            title={label}
+        >
+            LoTW {symbol}
+        </span>
+    );
+}
+
 const pota_columns = [
     { title: "Time", field: "time" },
     { title: "", field: "flag", sorting: false },
@@ -386,11 +429,14 @@ const Spot = forwardRef(function Spot(
                     }}
                     onMouseLeave={() => set_is_missing_hovered(false)}
                 >
-                    <span
-                        className={is_missing_alerted ? "inline-block rounded px-1" : ""}
-                        style={is_missing_alerted ? missing_alert_callsign_style : undefined}
-                    >
-                        <Callsign callsign={spot.dx_callsign} />
+                    <span className="inline-flex items-center gap-1">
+                        <span
+                            className={is_missing_alerted ? "inline-block rounded px-1" : ""}
+                            style={is_missing_alerted ? missing_alert_callsign_style : undefined}
+                        >
+                            <Callsign callsign={spot.dx_callsign} />
+                        </span>
+                        <LoTWStatus status={spot.dx_lotw_status} />
                     </span>
                     {is_dxpedition_alerted && (
                         <span className="ml-1" title="DXpedition">

--- a/ui/src/components/SpotsTable.jsx
+++ b/ui/src/components/SpotsTable.jsx
@@ -162,20 +162,38 @@ export function get_lotw_status_details(status) {
     );
 }
 
-export function LoTWStatus({ status }) {
+export function LoTWStatus({ status, tooltip_style }) {
+    const popup_anchor = useRef(null);
+    const [is_hovered, set_is_hovered] = useState(false);
+
     if (status === "non_user") return null;
 
     const { label, symbol, className } = get_lotw_status_details(status);
 
     return (
-        <span
-            className={`inline-flex size-3 items-center justify-center rounded-full text-[9px] leading-none ${className}`}
-            role="img"
-            aria-label={label}
-            title={label}
-        >
-            {symbol}
-        </span>
+        <>
+            <span
+                ref={popup_anchor}
+                className={`inline-flex size-3 items-center justify-center rounded-full text-[9px] leading-none ${className}`}
+                role="img"
+                aria-label={label}
+                onMouseEnter={() => set_is_hovered(true)}
+                onMouseLeave={() => set_is_hovered(false)}
+            >
+                {symbol}
+            </span>
+            {is_hovered && (
+                <Popup anchor_ref={popup_anchor} keep_in_view={true}>
+                    <div
+                        className="py-1 px-2 rounded shadow-lg text-xs whitespace-nowrap"
+                        role="tooltip"
+                        style={tooltip_style}
+                    >
+                        {label}
+                    </div>
+                </Popup>
+            )}
+        </>
     );
 }
 
@@ -438,7 +456,13 @@ const Spot = forwardRef(function Spot(
                         >
                             <Callsign callsign={spot.dx_callsign} />
                         </span>
-                        <LoTWStatus status={spot.dx_lotw_status} />
+                        <LoTWStatus
+                            status={spot.dx_lotw_status}
+                            tooltip_style={{
+                                color: colors.theme.text,
+                                background: colors.theme.background,
+                            }}
+                        />
                     </span>
                     {is_dxpedition_alerted && (
                         <span className="ml-1" title="DXpedition">

--- a/ui/tests/lotw_status.jsx
+++ b/ui/tests/lotw_status.jsx
@@ -8,17 +8,22 @@ afterEach(cleanup);
 
 describe("LoTWStatus", () => {
     it.each([
-        ["frequent", "LoTW: active (last upload within 180 days)", "LoTW ✓"],
-        ["infrequent", "LoTW: user, last upload over 180 days ago", "LoTW ~"],
-        ["non_user", "LoTW: no user activity found", "LoTW —"],
-        [undefined, "LoTW status unavailable", "LoTW ?"],
-        ["unexpected", "LoTW status unavailable", "LoTW ?"],
+        ["frequent", "LoTW: active (last upload within 180 days)", "✓"],
+        ["infrequent", "LoTW: user, last upload over 180 days ago", "~"],
+        [undefined, "LoTW status unavailable", "?"],
+        ["unexpected", "LoTW status unavailable", "?"],
     ])("exposes %s status with text and tooltip", (status, label, text) => {
         render(<LoTWStatus status={status} />);
 
         const indicator = screen.getByRole("img", { name: label });
         expect(indicator.textContent).toBe(text);
         expect(indicator.getAttribute("title")).toBe(label);
+    });
+
+    it("does not render an indicator when no LoTW user activity is found", () => {
+        render(<LoTWStatus status="non_user" />);
+
+        expect(screen.queryByRole("img")).toBeNull();
     });
 });
 

--- a/ui/tests/lotw_status.jsx
+++ b/ui/tests/lotw_status.jsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { LoTWStatus } from "@/components/SpotsTable.jsx";
@@ -12,12 +12,15 @@ describe("LoTWStatus", () => {
         ["infrequent", "LoTW: user, last upload over 180 days ago", "~"],
         [undefined, "LoTW status unavailable", "?"],
         ["unexpected", "LoTW status unavailable", "?"],
-    ])("exposes %s status with text and tooltip", (status, label, text) => {
+    ])("exposes %s status with an accessible label", (status, label, text) => {
         render(<LoTWStatus status={status} />);
 
         const indicator = screen.getByRole("img", { name: label });
         expect(indicator.textContent).toBe(text);
-        expect(indicator.getAttribute("title")).toBe(label);
+        expect(indicator.getAttribute("title")).toBeNull();
+
+        fireEvent.mouseEnter(indicator);
+        expect(screen.getByRole("tooltip").textContent).toBe(label);
     });
 
     it("does not render an indicator when no LoTW user activity is found", () => {

--- a/ui/tests/lotw_status.jsx
+++ b/ui/tests/lotw_status.jsx
@@ -1,0 +1,44 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { LoTWStatus } from "@/components/SpotsTable.jsx";
+import { normalize_spots } from "@/utils/spot_cache_db.jsx";
+
+afterEach(cleanup);
+
+describe("LoTWStatus", () => {
+    it.each([
+        ["frequent", "LoTW: active (last upload within 180 days)", "LoTW ✓"],
+        ["infrequent", "LoTW: user, last upload over 180 days ago", "LoTW ~"],
+        ["non_user", "LoTW: no user activity found", "LoTW —"],
+        [undefined, "LoTW status unavailable", "LoTW ?"],
+        ["unexpected", "LoTW status unavailable", "LoTW ?"],
+    ])("exposes %s status with text and tooltip", (status, label, text) => {
+        render(<LoTWStatus status={status} />);
+
+        const indicator = screen.getByRole("img", { name: label });
+        expect(indicator.textContent).toBe(text);
+        expect(indicator.getAttribute("title")).toBe(label);
+    });
+});
+
+describe("historical spot normalization", () => {
+    it("preserves the LoTW status supplied by the API", () => {
+        const [spot] = normalize_spots([
+            {
+                time: 1_700_000_000,
+                spotter_callsign: "K1ABC",
+                dx_callsign: "K2ABC",
+                dx_lotw_status: "infrequent",
+                mode: "FT8",
+                band: 20,
+                dx_dxcc_code: 291,
+                spotter_dxcc_code: 291,
+                dx_continent: "NA",
+                spotter_continent: "NA",
+            },
+        ]);
+
+        expect(spot.dx_lotw_status).toBe("infrequent");
+    });
+});


### PR DESCRIPTION
## Summary
- show compact, accessible LoTW activity indicators beside DX callsigns
- omit the marker when no LoTW user activity is found and show status-unavailable data explicitly
- use the shared Popup component for status details

## Tests
- npm run check

## Risks
- relies on the existing backend LoTW activity classification; it does not assert QSO confirmation status.