### PR TITLE
Add Linux CAT server tray icon

### DIFF
--- a/.github/workflows/catserver.yml
+++ b/.github/workflows/catserver.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: Install Linux tray dependencies
-        run: sudo apt-get update && sudo apt-get install --yes libgtk-3-dev libappindicator3-dev
+        run: sudo apt-get update && sudo apt-get install --yes libgtk-3-dev libappindicator3-dev libusb-1.0-0-dev
       - name: Build Linux CAT server
         working-directory: catserver
         run: cargo build --workspace

--- a/.github/workflows/catserver.yml
+++ b/.github/workflows/catserver.yml
@@ -21,6 +21,20 @@ env:
   TARGET: x86_64-pc-windows-gnu
 
 jobs:
+  check-linux-tray:
+    name: Check Linux tray support
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Install Linux tray dependencies
+        run: sudo apt-get update && sudo apt-get install --yes libgtk-3-dev libappindicator3-dev
+      - name: Build Linux CAT server
+        working-directory: catserver
+        run: cargo build --workspace
+
   build-catserver:
     name: Build Catserver
     runs-on: ubuntu-latest

--- a/catserver/Cargo.lock
+++ b/catserver/Cargo.lock
@@ -306,6 +306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,10 +396,12 @@ dependencies = [
  "axum",
  "directories",
  "futures-util",
+ "gtk",
  "hamlib",
  "hyper",
  "hyper-tls",
  "hyper-util",
+ "ico",
  "open",
  "reqwest",
  "serde",
@@ -1300,6 +1308,16 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "ico"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
+dependencies = [
+ "byteorder",
+ "png",
 ]
 
 [[package]]

--- a/catserver/Cargo.toml
+++ b/catserver/Cargo.toml
@@ -39,6 +39,10 @@ tray-icon = { version = "0.20.1", default-features = false }
 winit = "0.30.10"
 winsafe = { version = "0.0.25", features = ["kernel", "ole", "oleaut"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18.2"
+ico = "0.4.0"
+
 [build-dependencies]
 winresource = "0.1.20"
 

--- a/catserver/README.md
+++ b/catserver/README.md
@@ -1,0 +1,15 @@
+# CAT server
+
+## Linux tray requirements
+
+The Linux system-tray icon uses GTK3 and AppIndicator. Install the runtime
+packages before running the CAT server:
+
+```sh
+sudo apt install libgtk-3-0 libappindicator3-1
+```
+
+`libayatana-appindicator3-1` can be used instead where it provides the
+AppIndicator compatibility library. Desktop environments must expose a StatusNotifier/AppIndicator host for the icon to appear.
+
+For development builds, install `libgtk-3-dev` and `libappindicator3-dev`.

--- a/catserver/src/application.rs
+++ b/catserver/src/application.rs
@@ -54,7 +54,7 @@ pub fn run() -> Result<()> {
                     tracing::error!(?error, "Singleton instance failed");
                 }
             })?;
-        if cfg!(windows) {
+        if cfg!(any(windows, target_os = "linux")) {
             tray_icon::run_tray_icon(sender.clone(), sender.subscribe());
         } else if let Err(error) = thread.join() {
             let message = error

--- a/catserver/src/tray_icon.rs
+++ b/catserver/src/tray_icon.rs
@@ -1,9 +1,10 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tokio::sync::broadcast::{Receiver, Sender};
 use tray_icon::{
-    TrayIconBuilder,
+    TrayIcon, TrayIconBuilder,
     menu::{Menu, MenuEvent, MenuItem},
 };
+#[cfg(windows)]
 use winit::{application::ApplicationHandler, event_loop::ActiveEventLoop};
 
 #[cfg(windows)]
@@ -12,7 +13,20 @@ fn add_icon_to_tray_icon(tray_icon: TrayIconBuilder) -> Result<TrayIconBuilder> 
     Ok(tray_icon.with_icon(Icon::from_resource(1, Some((32, 32)))?))
 }
 
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
+fn add_icon_to_tray_icon(tray_icon: TrayIconBuilder) -> Result<TrayIconBuilder> {
+    let icon_dir = ico::IconDir::read(std::io::Cursor::new(include_bytes!("../wix/icon.ico")))?;
+    let image = icon_dir
+        .entries()
+        .first()
+        .context("The bundled Windows icon contains no images")?
+        .decode()?;
+    let (width, height) = (image.width(), image.height());
+    let icon = tray_icon::Icon::from_rgba(image.rgba_data().to_vec(), width, height)?;
+    Ok(tray_icon.with_icon(icon))
+}
+
+#[cfg(not(any(windows, target_os = "linux")))]
 fn add_icon_to_tray_icon(tray_icon: TrayIconBuilder) -> Result<TrayIconBuilder> {
     Ok(tray_icon)
 }
@@ -23,37 +37,24 @@ pub enum UserEvent {
     OpenBrowser,
 }
 
-pub fn run_tray_icon(tray_sender: Sender<UserEvent>, mut tray_receiver: Receiver<UserEvent>) {
+fn create_tray_icon() -> Result<(TrayIcon, MenuItem, MenuItem)> {
     let open_menu_item = MenuItem::new("Open", true, None);
     let quit_menu_item = MenuItem::new("Quit", true, None);
     let tray_menu = Menu::new();
     let instance_title = "Holy Cluster";
     if let Err(error) = tray_menu.append_items(&[&open_menu_item, &quit_menu_item]) {
-        tracing::error!(?error, "Failed to build tray menu");
-        return;
+        return Err(error.into());
     }
     let tray_icon = TrayIconBuilder::new()
         .with_menu(Box::new(tray_menu))
         .with_tooltip(instance_title)
         .with_title(instance_title);
-    let tray_icon = match add_icon_to_tray_icon(tray_icon) {
-        Ok(tray_icon) => tray_icon,
-        Err(error) => {
-            tracing::error!(?error, "Failed to load tray icon");
-            return;
-        }
-    };
-    let _tray_icon = match tray_icon.build() {
-        Ok(tray_icon) => tray_icon,
-        Err(error) => {
-            tracing::error!(?error, "Failed to create tray icon");
-            return;
-        }
-    };
+    let tray_icon = add_icon_to_tray_icon(tray_icon)?.build()?;
+    Ok((tray_icon, open_menu_item, quit_menu_item))
+}
 
-    let quit_menu_id = quit_menu_item.id().clone();
-    let open_menu_id = open_menu_item.id().clone();
-
+#[cfg(windows)]
+pub fn run_tray_icon(tray_sender: Sender<UserEvent>, mut tray_receiver: Receiver<UserEvent>) {
     let event_loop = match winit::event_loop::EventLoop::<UserEvent>::with_user_event().build() {
         Ok(event_loop) => event_loop,
         Err(error) => {
@@ -62,23 +63,6 @@ pub fn run_tray_icon(tray_sender: Sender<UserEvent>, mut tray_receiver: Receiver
         }
     };
     let proxy = event_loop.create_proxy();
-
-    MenuEvent::set_event_handler(Some({
-        let proxy = proxy.clone();
-        move |event: MenuEvent| {
-            let id = event.id();
-            if id == &open_menu_id {
-                let _ = tray_sender.send(UserEvent::OpenBrowser);
-            } else if id == &quit_menu_id {
-                if let Err(error) = tray_sender.send(UserEvent::Quit) {
-                    tracing::error!(?error, "Failed to send tray quit event");
-                }
-                if let Err(error) = proxy.send_event(UserEvent::Quit) {
-                    tracing::error!(?error, "Failed to notify tray event loop to quit");
-                }
-            }
-        }
-    }));
 
     let proxy_clone = proxy.clone();
     std::thread::spawn(move || {
@@ -90,9 +74,44 @@ pub fn run_tray_icon(tray_sender: Sender<UserEvent>, mut tray_receiver: Receiver
         }
     });
 
-    struct App {}
+    struct App {
+        tray_icon: Option<TrayIcon>,
+        tray_sender: Sender<UserEvent>,
+    }
     impl ApplicationHandler<UserEvent> for App {
         fn resumed(&mut self, _event_loop: &ActiveEventLoop) {}
+
+        fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: winit::event::StartCause) {
+            if cause != winit::event::StartCause::Init {
+                return;
+            }
+            let (tray_icon, open_menu_item, quit_menu_item) = match create_tray_icon() {
+                Ok(tray_icon) => tray_icon,
+                Err(error) => {
+                    tracing::error!(?error, "Failed to create tray icon");
+                    event_loop.exit();
+                    return;
+                }
+            };
+            let open_menu_id = open_menu_item.id().clone();
+            let quit_menu_id = quit_menu_item.id().clone();
+            let proxy = event_loop.create_proxy();
+            let tray_sender = self.tray_sender.clone();
+            MenuEvent::set_event_handler(Some(move |event: MenuEvent| {
+                let id = event.id();
+                if id == &open_menu_id {
+                    let _ = tray_sender.send(UserEvent::OpenBrowser);
+                } else if id == &quit_menu_id {
+                    if let Err(error) = tray_sender.send(UserEvent::Quit) {
+                        tracing::error!(?error, "Failed to send tray quit event");
+                    }
+                    if let Err(error) = proxy.send_event(UserEvent::Quit) {
+                        tracing::error!(?error, "Failed to notify tray event loop to quit");
+                    }
+                }
+            }));
+            self.tray_icon = Some(tray_icon);
+        }
 
         fn user_event(&mut self, event_loop: &ActiveEventLoop, event: UserEvent) {
             if event == UserEvent::Quit {
@@ -109,8 +128,46 @@ pub fn run_tray_icon(tray_sender: Sender<UserEvent>, mut tray_receiver: Receiver
         }
     }
 
-    let mut app = App {};
+    let mut app = App {
+        tray_icon: None,
+        tray_sender,
+    };
     if let Err(error) = event_loop.run_app(&mut app) {
         tracing::error!(?error, "Tray event loop failed");
     }
+}
+
+#[cfg(target_os = "linux")]
+pub fn run_tray_icon(tray_sender: Sender<UserEvent>, mut tray_receiver: Receiver<UserEvent>) {
+    if let Err(error) = gtk::init() {
+        tracing::error!(?error, "Failed to initialize GTK tray event loop");
+        return;
+    }
+    let (tray_icon, open_menu_item, quit_menu_item) = match create_tray_icon() {
+        Ok(tray_icon) => tray_icon,
+        Err(error) => {
+            tracing::error!(?error, "Failed to create tray icon");
+            return;
+        }
+    };
+    let open_menu_id = open_menu_item.id().clone();
+    let quit_menu_id = quit_menu_item.id().clone();
+    MenuEvent::set_event_handler(Some(move |event: MenuEvent| {
+        let id = event.id();
+        if id == &open_menu_id {
+            let _ = tray_sender.send(UserEvent::OpenBrowser);
+        } else if id == &quit_menu_id && tray_sender.send(UserEvent::Quit).is_err() {
+            tracing::error!("Failed to send tray quit event");
+        }
+    }));
+    std::thread::spawn(move || {
+        while let Ok(event) = tray_receiver.blocking_recv() {
+            if event == UserEvent::Quit {
+                gtk::glib::MainContext::default().invoke(gtk::main_quit);
+                break;
+            }
+        }
+    });
+    let _tray_icon = tray_icon;
+    gtk::main();
 }

--- a/catserver/src/tray_icon.rs
+++ b/catserver/src/tray_icon.rs
@@ -1,11 +1,16 @@
-use anyhow::{Context, Result};
+#[cfg(target_os = "linux")]
+use anyhow::Context;
+use anyhow::Result;
 use tokio::sync::broadcast::{Receiver, Sender};
 use tray_icon::{
     TrayIcon, TrayIconBuilder,
     menu::{Menu, MenuEvent, MenuItem},
 };
 #[cfg(windows)]
-use winit::{application::ApplicationHandler, event_loop::ActiveEventLoop};
+use winit::{
+    application::ApplicationHandler,
+    event_loop::{ActiveEventLoop, EventLoopProxy},
+};
 
 #[cfg(windows)]
 fn add_icon_to_tray_icon(tray_icon: TrayIconBuilder) -> Result<TrayIconBuilder> {
@@ -77,6 +82,7 @@ pub fn run_tray_icon(tray_sender: Sender<UserEvent>, mut tray_receiver: Receiver
     struct App {
         tray_icon: Option<TrayIcon>,
         tray_sender: Sender<UserEvent>,
+        proxy: EventLoopProxy<UserEvent>,
     }
     impl ApplicationHandler<UserEvent> for App {
         fn resumed(&mut self, _event_loop: &ActiveEventLoop) {}
@@ -95,7 +101,7 @@ pub fn run_tray_icon(tray_sender: Sender<UserEvent>, mut tray_receiver: Receiver
             };
             let open_menu_id = open_menu_item.id().clone();
             let quit_menu_id = quit_menu_item.id().clone();
-            let proxy = event_loop.create_proxy();
+            let proxy = self.proxy.clone();
             let tray_sender = self.tray_sender.clone();
             MenuEvent::set_event_handler(Some(move |event: MenuEvent| {
                 let id = event.id();
@@ -131,6 +137,7 @@ pub fn run_tray_icon(tray_sender: Sender<UserEvent>, mut tray_receiver: Receiver
     let mut app = App {
         tray_icon: None,
         tray_sender,
+        proxy,
     };
     if let Err(error) = event_loop.run_app(&mut app) {
         tracing::error!(?error, "Tray event loop failed");


### PR DESCRIPTION
## Summary
- run the CAT server tray on Linux through GTK/AppIndicator
- reuse the Windows icon asset and preserve the Windows Winit lifecycle
- document Linux requirements and add a Linux CI build check

## Tests
- cargo fmt
- cargo check
- cargo build
- cargo test --workspace
- manual GTK/AppIndicator tray check with dummy CAT server

## Platform constraints
- requires GTK3 and an AppIndicator/StatusNotifier host