### PR TITLE
Add native CAT Control update flow

### DIFF
--- a/ui/src/components/About.jsx
+++ b/ui/src/components/About.jsx
@@ -1,11 +1,10 @@
 import { useLocalStorage } from "@uidotdev/usehooks";
 import { useEffect, useState } from "react";
 
-import Button from "@/components/ui/Button.jsx";
+import UpdateControls from "@/components/UpdateControls.jsx";
 import Modal from "@/components/ui/Modal.jsx";
 import Tabs from "@/components/ui/Tabs.jsx";
 import { useColors } from "@/hooks/useColors.jsx";
-import use_radio from "@/hooks/useRadio.jsx";
 
 const RELEASES = [
     [
@@ -183,7 +182,6 @@ function Info({ size }) {
 
 function About() {
     const { colors } = useColors();
-    const { raw_local_version, raw_remote_version, new_version_available } = use_radio();
 
     const about = (
         <div className="p-2">
@@ -255,13 +253,7 @@ function About() {
                 </a>
             </p>
             Contact us at: <strong>holycluster@iarc.org</strong>
-            {raw_local_version != null ? (
-                <p>
-                    CAT Version: <code>{raw_local_version}</code>
-                </p>
-            ) : (
-                ""
-            )}
+            <UpdateControls />
         </div>
     );
 
@@ -283,23 +275,6 @@ function About() {
 
     const release_notes = (
         <div className="p-2">
-            {new_version_available && (
-                <div className="mb-4 p-4 bg-blue-100 dark:bg-blue-900 rounded-lg">
-                    <div className="flex flex-col items-center space-y-2">
-                        <p className="text-lg font-semibold">New version available!</p>
-                        <p>Current version: {raw_local_version}</p>
-                        <p>Latest version: {raw_remote_version}</p>
-                        <Button
-                            className="px-4 py-2"
-                            on_click={() => {
-                                window.location.href = "/catserver/download";
-                            }}
-                        >
-                            Download Update
-                        </Button>
-                    </div>
-                </div>
-            )}
             {RELEASES.map(([date, changes]) => {
                 return (
                     <div className="pb-4" key={date}>

--- a/ui/src/components/MainContainer.jsx
+++ b/ui/src/components/MainContainer.jsx
@@ -5,6 +5,7 @@ import SidePanel from "@/components/SidePanel.jsx";
 import SpotsTable from "@/components/SpotsTable.jsx";
 import TopBar from "@/components/TopBar.jsx";
 import UnsupportedVersion from "@/components/UnsupportedVersion.jsx";
+import { UpdateConsentDialog } from "@/components/UpdateControls.jsx";
 import HistoryBar from "@/components/history/HistoryBar.jsx";
 import WebsiteTour from "@/components/tour/WebsiteTour.jsx";
 import {
@@ -399,6 +400,7 @@ function MainContent({
 
     return (
         <div className="flex flex-col h-full" data-tour="app-shell">
+            <UpdateConsentDialog />
             <TopBar
                 set_map_controls={set_map_controls}
                 set_radius_in_km={set_radius_in_km}

--- a/ui/src/components/UnsupportedVersion.jsx
+++ b/ui/src/components/UnsupportedVersion.jsx
@@ -1,8 +1,10 @@
 import Button from "@/components/ui/Button";
 import { useColors } from "@/hooks/useColors";
+import { useUpdate } from "@/hooks/useUpdate.jsx";
 
 function UnsupportedVersion() {
     const { colors } = useColors();
+    const { install } = useUpdate();
 
     return (
         <div
@@ -21,12 +23,7 @@ function UnsupportedVersion() {
                     The version of CAT Control you are using is no longer supported. Please upgrade
                     to the latest version.
                 </div>
-                <Button
-                    className="px-4 py-2"
-                    on_click={() => {
-                        window.location.href = "/catserver/download";
-                    }}
-                >
+                <Button className="px-4 py-2" on_click={install}>
                     Upgrade Now
                 </Button>
             </div>

--- a/ui/src/components/UpdateControls.jsx
+++ b/ui/src/components/UpdateControls.jsx
@@ -1,0 +1,73 @@
+import Button from "@/components/ui/Button.jsx";
+import Modal from "@/components/ui/Modal.jsx";
+import { useUpdate } from "@/hooks/useUpdate.jsx";
+
+export function UpdateConsentDialog() {
+    const { status, remote_version, defer, install } = useUpdate();
+    const is_available = status === "available";
+
+    return (
+        <Modal
+            title={<h2 className="text-xl">CAT Control update available</h2>}
+            button={<span aria-hidden="true" />}
+            external_open={is_available}
+            on_cancel={() => defer()}
+            on_apply={() => {
+                install();
+                return true;
+            }}
+            apply_text="Update"
+            cancel_text="Later"
+            modal_style={{ width: "30rem" }}
+        >
+            <p className="p-4">Version {remote_version ?? ""} is ready to install.</p>
+        </Modal>
+    );
+}
+
+function message_for(status, error) {
+    const messages = {
+        loading: "Checking for CAT Control updates…",
+        checking: "Checking for CAT Control updates…",
+        current: "CAT Control is up to date.",
+        newer_local: "Your installed CAT Control is newer than the available release.",
+        unavailable: "CAT Control update service is unavailable.",
+        malformed: "CAT Control update information is unavailable.",
+        deferred: "CAT Control update available. You chose to install it later.",
+        installing: "Installing CAT Control. The connection may close while it restarts.",
+        unsupported: "Automatic updates are not supported on this platform.",
+        failed: error ?? "CAT Control update failed.",
+    };
+    return messages[status] ?? null;
+}
+
+export default function UpdateControls() {
+    const { status, local_version, remote_version, error, check, install, retry } = useUpdate();
+    const message = message_for(status, error);
+    const can_install = status === "available" || status === "deferred";
+
+    return (
+        <section aria-live="polite" className="mt-4 rounded-lg border border-blue-300 p-4">
+            <h2 className="text-lg font-semibold">CAT Control updates</h2>
+            {local_version && <p>Installed version: {local_version}</p>}
+            {remote_version && <p>Available version: {remote_version}</p>}
+            {message && <p>{message}</p>}
+            <div className="mt-3 flex flex-wrap gap-2">
+                <Button disabled={status === "loading" || status === "checking"} on_click={check}>
+                    Check for updates
+                </Button>
+                {can_install && <Button on_click={install}>Install update</Button>}
+                {status === "failed" && <Button on_click={retry}>Retry update</Button>}
+                {status === "unsupported" && (
+                    <a
+                        className="rounded-lg bg-blue-600 p-2 text-sm font-medium text-white"
+                        href="/catserver/download"
+                        download
+                    >
+                        Download manually
+                    </a>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/ui/src/components/UtilityButtons.jsx
+++ b/ui/src/components/UtilityButtons.jsx
@@ -1,7 +1,6 @@
 import About from "@/components/About.jsx";
 import { useColors } from "@/hooks/useColors";
-import use_radio from "@/hooks/useRadio.jsx";
-import { useEffect, useState } from "react";
+import { useUpdate } from "@/hooks/useUpdate.jsx";
 
 function FeedbackButton({ size }) {
     const { colors } = useColors();
@@ -24,13 +23,13 @@ function FeedbackButton({ size }) {
     );
 }
 
-function CatserverDownload({ size, new_version_available }) {
+function CatserverDownload({ size, update_available }) {
     const { colors } = useColors();
 
     return (
         <div data-tour="cat-download-link">
             <a href="/addons" target="_blank" rel="noreferrer">
-                {new_version_available ? (
+                {update_available ? (
                     <span className="absolute right-16 flex w-5 -translate-y-1 translate-x-1 z-10">
                         <span className="relative inline-flex border border-gray-900 bg-orange-600 text-white font-medium justify-center items-center rounded-full h-5 w-5 text-center text-[12px]">
                             !
@@ -48,11 +47,14 @@ function CatserverDownload({ size, new_version_available }) {
 }
 
 function UtilityButtons() {
-    const { local_version, new_version_available } = use_radio();
+    const { status } = useUpdate();
 
     return (
         <div className="space-y-3" data-tour="utility-buttons">
-            <CatserverDownload size="36" new_version_available={new_version_available} />
+            <CatserverDownload
+                size="36"
+                update_available={status === "available" || status === "deferred"}
+            />
             <FeedbackButton size="36" />
             <About />
         </div>

--- a/ui/src/components/addons/Download.jsx
+++ b/ui/src/components/addons/Download.jsx
@@ -1,9 +1,7 @@
+import UpdateControls from "@/components/UpdateControls.jsx";
 import Card from "@/components/addons/components/Card";
-import use_radio from "@/hooks/useRadio.jsx";
 
 export default function Download() {
-    const { filename } = use_radio();
-
     return (
         <section id="download" className="py-8 px-4 bg-addons-bg">
             <div className="container mx-auto">
@@ -12,24 +10,7 @@ export default function Download() {
                         <h2 className="text-3xl font-bold text-center mb-6 text-addons-primary">
                             Download CAT Server
                         </h2>
-                        <div className="text-center mb-4">
-                            <h3 className="text-xl font-bold addons-primary mb-2">{filename}</h3>
-                            <p className="text-gray-600" />
-                        </div>
-
-                        <div className="grid md:grid-cols-3 gap-4 mb-4">
-                            <Card className="p-5 flex flex-col items-center text-center md:col-start-2 hover:shadow-md transition-shadow">
-                                <h4 className="font-medium mb-2">Windows</h4>
-                                <p className="text-sm text-gray-600 mb-3">Windows 10/11 (64-bit)</p>
-                                <a
-                                    className="w-full text-white bg-addons-secondary hover:bg-addons-primary p-4 rounded-lg"
-                                    href="/catserver/download"
-                                    download
-                                >
-                                    Download .msi
-                                </a>
-                            </Card>
-                        </div>
+                        <UpdateControls />
                     </Card>
                 </div>
             </div>

--- a/ui/src/hooks/useRadio.jsx
+++ b/ui/src/hooks/useRadio.jsx
@@ -1,5 +1,5 @@
 import { compare_version } from "@/utils.js";
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import { createContext, useContext, useRef, useState } from "react";
 import raw_band_plans from "../../../shared/band_plans.json";
 import { useSettings } from "./useSettings";
 import { useWs, useWsMessage } from "./useWs";
@@ -28,45 +28,6 @@ function parse_version(raw_version) {
         Number.parseInt(patch, 10),
         commit ? Number.parseInt(commit, 10) : 0,
     ];
-}
-
-export function useCatserverVersion(raw_local_version) {
-    const [raw_remote_version, set_raw_remote_version] = useState(null);
-    const [new_version_available, set_new_version_available] = useState(false);
-    const [filename, set_filename] = useState("");
-
-    const local_version = parse_version(raw_local_version);
-    const remote_version = parse_version(raw_remote_version);
-
-    useEffect(() => {
-        if (raw_local_version == null) {
-            return;
-        }
-
-        fetch("/catserver/latest")
-            .then(data => data.text())
-            .then(data => {
-                set_filename(data);
-                const raw_remote_version = data.slice(0, data.lastIndexOf("."));
-                set_raw_remote_version(raw_remote_version);
-
-                if (compare_version(local_version, parse_version(raw_remote_version)) > 0) {
-                    set_new_version_available(true);
-                    console.log(
-                        `New version available - Remote: ${raw_remote_version}, Local: ${local_version}`,
-                    );
-                }
-            });
-    }, [raw_local_version]);
-
-    return {
-        local_version,
-        remote_version,
-        raw_local_version,
-        raw_remote_version,
-        new_version_available,
-        filename,
-    };
 }
 
 const RadioContext = createContext(null);
@@ -164,12 +125,12 @@ export function RadioProvider({ children }) {
         return radio_ready && radio_status !== "unavailable";
     }
 
-    const version_data = useCatserverVersion(raw_local_version);
+    const local_version = parse_version(raw_local_version);
 
     const tagged_api_version = [1, 1, 0, 0];
 
     function highlight_spot(spot, udp_port) {
-        if (spot && compare_version(version_data.local_version, tagged_api_version) > 0) {
+        if (spot && compare_version(local_version, tagged_api_version) > 0) {
             send_message_to_radio({
                 action: "HighlightSpot",
                 dx_callsign: spot.dx_callsign,
@@ -259,7 +220,7 @@ export function RadioProvider({ children }) {
                 radio_configuration,
                 radio_configuration_result,
                 radio_retry_result,
-                ...version_data,
+                local_version,
             }}
         >
             {children}

--- a/ui/src/hooks/useUpdate.jsx
+++ b/ui/src/hooks/useUpdate.jsx
@@ -1,0 +1,164 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+const UpdateContext = createContext(null);
+
+function parse_version(value) {
+    if (typeof value !== "string") return null;
+    const match = value.trim().match(/^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[-+].*)?$/);
+    if (!match) return null;
+    return match.slice(1).map(part => Number.parseInt(part ?? "0", 10));
+}
+
+export function compare_update_versions(local, remote) {
+    const local_version = parse_version(local);
+    const remote_version = parse_version(remote);
+    if (!local_version || !remote_version) return null;
+
+    const length = Math.max(local_version.length, remote_version.length);
+    for (let index = 0; index < length; index++) {
+        const difference = (remote_version[index] ?? 0) - (local_version[index] ?? 0);
+        if (difference !== 0) return difference;
+    }
+    return 0;
+}
+
+function get_versions(version) {
+    if (typeof version === "string") return { local: null, remote: version };
+    if (!version || typeof version !== "object" || Array.isArray(version)) {
+        return { local: null, remote: null };
+    }
+    return {
+        local: version.local ?? version.current ?? version.installed ?? null,
+        remote: version.remote ?? version.latest ?? version.available ?? null,
+    };
+}
+
+export function normalize_update_status(payload) {
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        return { status: "malformed", local_version: null, remote_version: null, error: null };
+    }
+
+    const { local, remote } = get_versions(payload.version);
+    const status = typeof payload.status === "string" ? payload.status : "malformed";
+    const error = typeof payload.error === "string" ? payload.error : null;
+    const direction = compare_update_versions(local, remote);
+    const aliases = {
+        unavailable: "unavailable",
+        unsupported: "unsupported",
+        manual: "unsupported",
+        deferred: "deferred",
+        loading: "loading",
+        checking: "checking",
+        installing: "installing",
+        failed: "failed",
+        error: "failed",
+    };
+
+    if (aliases[status]) {
+        return {
+            status: aliases[status],
+            local_version: local,
+            remote_version: remote,
+            error,
+        };
+    }
+
+    if (local != null && remote != null && direction == null) {
+        return { status: "malformed", local_version: local, remote_version: remote, error };
+    }
+    if (direction > 0)
+        return { status: "available", local_version: local, remote_version: remote, error };
+    if (direction === 0)
+        return { status: "current", local_version: local, remote_version: remote, error };
+    if (direction < 0)
+        return { status: "newer_local", local_version: local, remote_version: remote, error };
+
+    const status_aliases = {
+        available: "available",
+        update_available: "available",
+        current: "current",
+        equal: "current",
+        up_to_date: "current",
+        newer_local: "newer_local",
+    };
+    return {
+        status: status_aliases[status] ?? "malformed",
+        local_version: local,
+        remote_version: remote,
+        error,
+    };
+}
+
+async function request_update(path) {
+    const response = await fetch(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+    });
+    if (!response.ok) throw new Error(`Update request failed (${response.status})`);
+    return normalize_update_status(await response.json());
+}
+
+export function UpdateProvider({ children }) {
+    const [update, set_update] = useState({
+        status: "loading",
+        local_version: null,
+        remote_version: null,
+        error: null,
+    });
+
+    const refresh = useCallback(async () => {
+        set_update(current => ({ ...current, status: "loading", error: null }));
+        try {
+            const response = await fetch("/update/status");
+            if (!response.ok) throw new Error(`Update status failed (${response.status})`);
+            set_update(normalize_update_status(await response.json()));
+        } catch (error) {
+            set_update(current => ({ ...current, status: "unavailable", error: error.message }));
+        }
+    }, []);
+
+    useEffect(() => {
+        refresh();
+    }, [refresh]);
+
+    const action = useCallback(async path => {
+        set_update(current => ({
+            ...current,
+            status: path === "/update/install" ? "installing" : "checking",
+            error: null,
+        }));
+        try {
+            const next = await request_update(path);
+            set_update(next);
+            return next;
+        } catch (error) {
+            if (path === "/update/install") {
+                set_update(current => ({ ...current, status: "installing", error: null }));
+                return null;
+            }
+            set_update(current => ({ ...current, status: "failed", error: error.message }));
+            return null;
+        }
+    }, []);
+
+    const value = useMemo(
+        () => ({
+            ...update,
+            refresh,
+            check: () => action("/update/check"),
+            install: () => action("/update/install"),
+            defer: () => action("/update/defer"),
+            retry: () => action("/update/retry"),
+        }),
+        [update, refresh, action],
+    );
+
+    return <UpdateContext.Provider value={value}>{children}</UpdateContext.Provider>;
+}
+
+export function useUpdate() {
+    const update = useContext(UpdateContext);
+    if (!update) throw new Error("useUpdate must be used within UpdateProvider");
+    return update;
+}

--- a/ui/src/hooks/useUpdate.jsx
+++ b/ui/src/hooks/useUpdate.jsx
@@ -28,8 +28,10 @@ function get_versions(version) {
         return { local: null, remote: null };
     }
     return {
-        local: version.local ?? version.current ?? version.installed ?? null,
-        remote: version.remote ?? version.latest ?? version.available ?? null,
+        local:
+            version.local ?? version.local_version ?? version.current ?? version.installed ?? null,
+        remote:
+            version.remote ?? version.remote_version ?? version.latest ?? version.available ?? null,
     };
 }
 
@@ -112,7 +114,11 @@ export function UpdateProvider({ children }) {
         try {
             const response = await fetch("/update/status");
             if (!response.ok) throw new Error(`Update status failed (${response.status})`);
-            set_update(normalize_update_status(await response.json()));
+            try {
+                set_update(normalize_update_status(await response.json()));
+            } catch {
+                set_update(current => ({ ...current, status: "malformed" }));
+            }
         } catch (error) {
             set_update(current => ({ ...current, status: "unavailable", error: error.message }));
         }

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -12,6 +12,7 @@ import { RadioProvider } from "@/hooks/useRadio";
 import { RotatorProvider } from "@/hooks/useRotator";
 import { SettingsProvider } from "@/hooks/useSettings";
 import { SpotInteractionProvider } from "@/hooks/useSpotInteraction";
+import { UpdateProvider } from "@/hooks/useUpdate";
 import { WsProvider } from "@/hooks/useWs";
 import "@/index.css";
 
@@ -27,13 +28,15 @@ ReactDOM.createRoot(document.getElementById("root")).render(
                                 <ColorsProvider>
                                     <FiltersProvider>
                                         <SettingsProvider>
-                                            <RadioProvider>
-                                                <RotatorProvider>
-                                                    <SpotInteractionProvider>
-                                                        <MainContainer />
-                                                    </SpotInteractionProvider>
-                                                </RotatorProvider>
-                                            </RadioProvider>
+                                            <UpdateProvider>
+                                                <RadioProvider>
+                                                    <RotatorProvider>
+                                                        <SpotInteractionProvider>
+                                                            <MainContainer />
+                                                        </SpotInteractionProvider>
+                                                    </RotatorProvider>
+                                                </RadioProvider>
+                                            </UpdateProvider>
                                         </SettingsProvider>
                                     </FiltersProvider>
                                 </ColorsProvider>
@@ -43,9 +46,11 @@ ReactDOM.createRoot(document.getElementById("root")).render(
                             path="/addons"
                             element={
                                 <SettingsProvider>
-                                    <RadioProvider>
-                                        <Addons />
-                                    </RadioProvider>
+                                    <UpdateProvider>
+                                        <RadioProvider>
+                                            <Addons />
+                                        </RadioProvider>
+                                    </UpdateProvider>
                                 </SettingsProvider>
                             }
                         />

--- a/ui/tests/about.jsx
+++ b/ui/tests/about.jsx
@@ -32,6 +32,19 @@ vi.mock("@/hooks/useRadio.jsx", () => ({
     }),
 }));
 
+vi.mock("@/hooks/useUpdate.jsx", () => ({
+    useUpdate: () => ({
+        status: "current",
+        local_version: "1.0.0",
+        remote_version: "1.0.0",
+        error: null,
+        check: vi.fn(),
+        install: vi.fn(),
+        retry: vi.fn(),
+        defer: vi.fn(),
+    }),
+}));
+
 describe("About release notes", () => {
     beforeEach(() => {
         window.localStorage.clear();

--- a/ui/tests/update_controls.jsx
+++ b/ui/tests/update_controls.jsx
@@ -1,0 +1,115 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import UpdateControls, { UpdateConsentDialog } from "@/components/UpdateControls.jsx";
+import {
+    UpdateProvider,
+    compare_update_versions,
+    normalize_update_status,
+} from "@/hooks/useUpdate.jsx";
+
+vi.mock("@/hooks/useColors", () => ({
+    useColors: () => ({ colors: { theme: { text: "#fff", modals: "#111", borders: "#333" } } }),
+}));
+
+function response(payload, ok = true) {
+    return { ok, status: ok ? 200 : 500, json: async () => payload };
+}
+
+function render_updates() {
+    return render(
+        <UpdateProvider>
+            <UpdateConsentDialog />
+            <UpdateControls />
+        </UpdateProvider>,
+    );
+}
+
+afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+});
+
+describe("CAT Control updates", () => {
+    it("only treats a newer remote version as an update", () => {
+        expect(compare_update_versions("1.2.0", "1.3.0")).toBeGreaterThan(0);
+        expect(compare_update_versions("1.3.0", "1.3.0")).toBe(0);
+        expect(compare_update_versions("1.4.0", "1.3.0")).toBeLessThan(0);
+        expect(
+            normalize_update_status({
+                status: "available",
+                version: { local_version: "1.4.0", remote_version: "1.3.0" },
+            }).status,
+        ).toBe("newer_local");
+        expect(
+            normalize_update_status({
+                status: "available",
+                version: { local: "bad", remote: "bad" },
+            }).status,
+        ).toBe("malformed");
+    });
+
+    it("installs after accepting the update prompt", async () => {
+        const fetch = vi
+            .fn()
+            .mockResolvedValueOnce(
+                response({ status: "available", version: { local: "1.0.0", remote: "1.1.0" } }),
+            )
+            .mockResolvedValueOnce(
+                response({ status: "installing", version: { local: "1.0.0", remote: "1.1.0" } }),
+            );
+        vi.stubGlobal("fetch", fetch);
+
+        render_updates();
+        await userEvent.click(await screen.findByRole("button", { name: "Update" }));
+        await waitFor(() =>
+            expect(fetch).toHaveBeenLastCalledWith("/update/install", expect.any(Object)),
+        );
+    });
+
+    it("keeps a declined update visible and installable later", async () => {
+        const fetch = vi
+            .fn()
+            .mockResolvedValueOnce(
+                response({ status: "available", version: { local: "1.0.0", remote: "1.1.0" } }),
+            )
+            .mockResolvedValueOnce(
+                response({ status: "deferred", version: { local: "1.0.0", remote: "1.1.0" } }),
+            )
+            .mockResolvedValueOnce(
+                response({ status: "installing", version: { local: "1.0.0", remote: "1.1.0" } }),
+            );
+        vi.stubGlobal("fetch", fetch);
+
+        render_updates();
+        await userEvent.click(await screen.findByRole("button", { name: "Later" }));
+        expect(await screen.findByText(/You chose to install it later/)).not.toBeNull();
+        await userEvent.click(screen.getByRole("button", { name: "Install update" }));
+        await waitFor(() =>
+            expect(fetch).toHaveBeenLastCalledWith("/update/install", expect.any(Object)),
+        );
+    });
+
+    it("offers retry after a failed update check", async () => {
+        const fetch = vi
+            .fn()
+            .mockResolvedValueOnce(
+                response({ status: "current", version: { local: "1.0.0", remote: "1.0.0" } }),
+            )
+            .mockResolvedValueOnce(response({}, false))
+            .mockResolvedValueOnce(
+                response({ status: "current", version: { local: "1.0.0", remote: "1.0.0" } }),
+            );
+        vi.stubGlobal("fetch", fetch);
+
+        render_updates();
+        await screen.findByText("CAT Control is up to date.");
+        await userEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+        expect(await screen.findByRole("button", { name: "Retry update" })).not.toBeNull();
+        await userEvent.click(screen.getByRole("button", { name: "Retry update" }));
+        await waitFor(() =>
+            expect(fetch).toHaveBeenLastCalledWith("/update/retry", expect.any(Object)),
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- use the structured local native updater status instead of CAT artifact filenames
- prompt for consent and preserve manual update controls after deferral
- retain a manual download fallback only for unsupported native updater platforms

Closes #357

## Tests
- `npm run check`

## Risks
- Requires the native updater routes to return the documented structured status payload.