### PR TITLE
Add privacy-safe Sentry UI reporting

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -47,10 +47,31 @@ jobs:
           cd ui
           npm test
 
+      - name: Set Sentry build metadata
+        run: |
+          echo "SENTRY_RELEASE=${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "VITE_SENTRY_RELEASE=${GITHUB_SHA}" >> "$GITHUB_ENV"
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "VITE_SENTRY_ENVIRONMENT=production" >> "$GITHUB_ENV"
+          else
+            echo "VITE_SENTRY_ENVIRONMENT=development" >> "$GITHUB_ENV"
+          fi
+
       - name: Build React App
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          VITE_SENTRY_DSN: ${{ vars.SENTRY_DSN }}
         run: |
           cd ui
           npm run build
+
+      - name: Remove source maps before deployment
+        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          shopt -s globstar nullglob
+          rm -f ui/dist/**/*.map
 
       - name: Setup SSH
         if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/utilities": "^3.2.2",
+                "@sentry/react": "^10.40.0",
                 "@uidotdev/usehooks": "^2.4.1",
                 "adif-parser-ts": "^0.7.3",
                 "d3": "^7.9.0",
@@ -1895,6 +1896,112 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@sentry/browser": {
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.69.0.tgz",
+            "integrity": "sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/browser-utils": "10.69.0",
+                "@sentry/conventions": "^0.16.0",
+                "@sentry/core": "10.69.0",
+                "@sentry/feedback": "10.69.0",
+                "@sentry/replay": "10.69.0",
+                "@sentry/replay-canvas": "10.69.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/browser-utils": {
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.69.0.tgz",
+            "integrity": "sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/conventions": "^0.16.0",
+                "@sentry/core": "10.69.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/conventions": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+            "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@sentry/core": {
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+            "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/conventions": "^0.16.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/feedback": {
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.69.0.tgz",
+            "integrity": "sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "10.69.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/react": {
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.69.0.tgz",
+            "integrity": "sha512-f0Il/JMteHjdWPNZQB3rtp1Pcj2Leb3p0KSZuv3rh0EUril9CbWtQVy5zJhoAppi+MWWmgRWa+6BpHbQf+ABQA==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/browser": "10.69.0",
+                "@sentry/conventions": "^0.16.0",
+                "@sentry/core": "10.69.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^16.14.0 || 17.x || 18.x || 19.x"
+            }
+        },
+        "node_modules/@sentry/replay": {
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.69.0.tgz",
+            "integrity": "sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/browser-utils": "10.69.0",
+                "@sentry/core": "10.69.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/replay-canvas": {
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.69.0.tgz",
+            "integrity": "sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "10.69.0",
+                "@sentry/replay": "10.69.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
@@ -3893,11 +4000,11 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -30,6 +30,7 @@
             },
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
+                "@sentry/vite-plugin": "^5.1.1",
                 "@testing-library/react": "^16.3.2",
                 "@testing-library/user-event": "^14.6.1",
                 "@types/react": "^18.3.3",
@@ -1927,6 +1928,295 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@sentry/bundler-plugins": {
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.69.0.tgz",
+            "integrity": "sha512-I1otnSJIH4IOugLp+kcBbT0Kcex+J8xnHuUyzMAwCYSpZ0FMVvA723uNmkMdW0PxRRw0oEhe0qDB+t+ZjHxUiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.18.5",
+                "@sentry/cli": "^2.58.6",
+                "@sentry/core": "10.69.0",
+                "dotenv": "^17.4.2",
+                "find-up": "^5.0.0",
+                "glob": "^13.0.6",
+                "magic-string": "~0.30.8"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "rollup": ">=3.2.0",
+                "webpack": ">=5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@sentry/bundler-plugins/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@sentry/bundler-plugins/node_modules/brace-expansion": {
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@sentry/bundler-plugins/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@sentry/bundler-plugins/node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@sentry/bundler-plugins/node_modules/minimatch": {
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.8"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@sentry/bundler-plugins/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@sentry/cli": {
+            "version": "2.58.6",
+            "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+            "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "FSL-1.1-MIT",
+            "dependencies": {
+                "https-proxy-agent": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "progress": "^2.0.3",
+                "proxy-from-env": "^1.1.0",
+                "which": "^2.0.2"
+            },
+            "bin": {
+                "sentry-cli": "bin/sentry-cli"
+            },
+            "engines": {
+                "node": ">= 10"
+            },
+            "optionalDependencies": {
+                "@sentry/cli-darwin": "2.58.6",
+                "@sentry/cli-linux-arm": "2.58.6",
+                "@sentry/cli-linux-arm64": "2.58.6",
+                "@sentry/cli-linux-i686": "2.58.6",
+                "@sentry/cli-linux-x64": "2.58.6",
+                "@sentry/cli-win32-arm64": "2.58.6",
+                "@sentry/cli-win32-i686": "2.58.6",
+                "@sentry/cli-win32-x64": "2.58.6"
+            }
+        },
+        "node_modules/@sentry/cli-darwin": {
+            "version": "2.58.6",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+            "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+            "dev": true,
+            "license": "FSL-1.1-MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-linux-arm": {
+            "version": "2.58.6",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+            "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "FSL-1.1-MIT",
+            "optional": true,
+            "os": [
+                "linux",
+                "freebsd",
+                "android"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-linux-arm64": {
+            "version": "2.58.6",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+            "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "FSL-1.1-MIT",
+            "optional": true,
+            "os": [
+                "linux",
+                "freebsd",
+                "android"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-linux-i686": {
+            "version": "2.58.6",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+            "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+            "cpu": [
+                "x86",
+                "ia32"
+            ],
+            "dev": true,
+            "license": "FSL-1.1-MIT",
+            "optional": true,
+            "os": [
+                "linux",
+                "freebsd",
+                "android"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-linux-x64": {
+            "version": "2.58.6",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+            "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "FSL-1.1-MIT",
+            "optional": true,
+            "os": [
+                "linux",
+                "freebsd",
+                "android"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-win32-arm64": {
+            "version": "2.58.6",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+            "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "FSL-1.1-MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-win32-i686": {
+            "version": "2.58.6",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+            "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+            "cpu": [
+                "x86",
+                "ia32"
+            ],
+            "dev": true,
+            "license": "FSL-1.1-MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-win32-x64": {
+            "version": "2.58.6",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+            "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "FSL-1.1-MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@sentry/conventions": {
             "version": "0.16.0",
             "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
@@ -2001,6 +2291,19 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/vite-plugin": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+            "integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/bundler-plugins": "^10.64.0"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@standard-schema/spec": {
@@ -2346,6 +2649,19 @@
             "engines": {
                 "node": ">=14.0.0",
                 "npm": ">7.0.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
             }
         },
         "node_modules/ansi-regex": {
@@ -3272,6 +3588,19 @@
                 "csstype": "^3.0.2"
             }
         },
+        "node_modules/dotenv": {
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3475,6 +3804,23 @@
             "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
             "license": "MIT"
         },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/foreground-child": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -3622,6 +3968,20 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/iconv-lite": {
@@ -3897,6 +4257,22 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "license": "MIT"
         },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4046,6 +4422,52 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/node-releases": {
             "version": "2.0.19",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -4106,6 +4528,38 @@
                 "node": ">=12.20.0"
             }
         },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -4154,6 +4608,16 @@
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/path-key": {
@@ -4439,6 +4903,16 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/prop-types": {
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4449,6 +4923,13 @@
                 "object-assign": "^4.1.1",
                 "react-is": "^16.13.1"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -5827,6 +6308,19 @@
             },
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         }
     }

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,6 +33,7 @@
     },
     "devDependencies": {
         "@biomejs/biome": "1.9.4",
+        "@sentry/vite-plugin": "^5.1.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",
+        "@sentry/react": "^10.40.0",
         "@uidotdev/usehooks": "^2.4.1",
         "adif-parser-ts": "^0.7.3",
         "d3": "^7.9.0",

--- a/ui/src/components/RouteErrorBoundary.jsx
+++ b/ui/src/components/RouteErrorBoundary.jsx
@@ -1,0 +1,47 @@
+import * as Sentry from "@sentry/react";
+import React from "react";
+
+class RouteErrorBoundary extends React.Component {
+    state = { has_error: false };
+
+    static getDerivedStateFromError() {
+        return { has_error: true };
+    }
+
+    componentDidCatch(error) {
+        Sentry.captureException(error);
+    }
+
+    retry = () => {
+        this.setState({ has_error: false });
+    };
+
+    render() {
+        if (this.state.has_error) {
+            return (
+                <main
+                    className="min-h-screen bg-blue-900 flex items-center justify-center p-4 text-white"
+                    role="alert"
+                >
+                    <section className="max-w-md w-full bg-white/10 backdrop-blur-lg rounded-xl shadow-2xl p-8 text-center border border-white/20">
+                        <h1 className="text-2xl font-bold mb-2">Something went wrong</h1>
+                        <p className="text-gray-200 mb-6">
+                            Please try again. If the problem continues, reload the page.
+                        </p>
+                        <button
+                            className="bg-blue-600 hover:bg-blue-700 py-3 px-6 rounded-lg font-semibold"
+                            onClick={this.retry}
+                            type="button"
+                        >
+                            Try again
+                        </button>
+                    </section>
+                </main>
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+export default RouteErrorBoundary;

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Routes } from "react-router";
 
 import MainContainer from "@/components/MainContainer.jsx";
 import OmniRigError from "@/components/OmniRigError.jsx";
+import RouteErrorBoundary from "@/components/RouteErrorBoundary.jsx";
 import Addons from "@/components/addons/Addons";
 import { ColorsProvider } from "@/hooks/useColors";
 import { FiltersProvider } from "@/hooks/useFilters";
@@ -15,6 +16,9 @@ import { SpotInteractionProvider } from "@/hooks/useSpotInteraction";
 import { UpdateProvider } from "@/hooks/useUpdate";
 import { WsProvider } from "@/hooks/useWs";
 import "@/index.css";
+import { initializeSentry } from "@/sentry";
+
+initializeSentry();
 
 ReactDOM.createRoot(document.getElementById("root")).render(
     <React.StrictMode>
@@ -25,32 +29,43 @@ ReactDOM.createRoot(document.getElementById("root")).render(
                         <Route
                             path="/"
                             element={
-                                <ColorsProvider>
-                                    <FiltersProvider>
-                                        <SettingsProvider>
-                                            <UpdateProvider>
-                                                <RadioProvider>
-                                                    <RotatorProvider>
-                                                        <SpotInteractionProvider>
-                                                            <MainContainer />
-                                                        </SpotInteractionProvider>
-                                                    </RotatorProvider>
-                                                </RadioProvider>
-                                            </UpdateProvider>
-                                        </SettingsProvider>
-                                    </FiltersProvider>
-                                </ColorsProvider>
+                                <RouteErrorBoundary>
+                                    <ColorsProvider>
+                                        <FiltersProvider>
+                                            <SettingsProvider>
+                                                <UpdateProvider>
+                                                    <RadioProvider>
+                                                        <RotatorProvider>
+                                                            <SpotInteractionProvider>
+                                                                <MainContainer />
+                                                            </SpotInteractionProvider>
+                                                        </RotatorProvider>
+                                                    </RadioProvider>
+                                                </UpdateProvider>
+                                            </SettingsProvider>
+                                        </FiltersProvider>
+                                    </ColorsProvider>
+                                </RouteErrorBoundary>
                             }
                         />
                         <Route
                             path="/addons"
                             element={
-                                <SettingsProvider>
-                                    <Addons />
-                                </SettingsProvider>
+                                <RouteErrorBoundary>
+                                    <SettingsProvider>
+                                        <Addons />
+                                    </SettingsProvider>
+                                </RouteErrorBoundary>
                             }
                         />
-                        <Route path="/omnirig-error" element={<OmniRigError />} />
+                        <Route
+                            path="/omnirig-error"
+                            element={
+                                <RouteErrorBoundary>
+                                    <OmniRigError />
+                                </RouteErrorBoundary>
+                            }
+                        />
                     </Routes>
                 </ProfilesProvider>
             </WsProvider>

--- a/ui/src/sentry.js
+++ b/ui/src/sentry.js
@@ -1,0 +1,51 @@
+import * as Sentry from "@sentry/react";
+
+const default_options = {
+    dsn: import.meta.env.VITE_SENTRY_DSN,
+    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT,
+    release: import.meta.env.VITE_SENTRY_RELEASE,
+};
+
+export function sanitizeSentryEvent(event) {
+    const {
+        breadcrumbs: _breadcrumbs,
+        contexts: _contexts,
+        extra: _extra,
+        request: _request,
+        user: _user,
+        ...sanitized_event
+    } = event;
+
+    if (event.exception?.values) {
+        sanitized_event.exception = {
+            ...event.exception,
+            values: event.exception.values.map(value => ({
+                ...value,
+                value: "Application error",
+            })),
+        };
+    }
+
+    return sanitized_event;
+}
+
+export function initializeSentry(options = {}) {
+    const settings = { ...default_options, ...options };
+
+    if (!settings.dsn) {
+        return false;
+    }
+
+    Sentry.init({
+        dsn: settings.dsn,
+        environment: settings.environment,
+        release: settings.release,
+        sendDefaultPii: false,
+        tracesSampleRate: 0,
+        replaysOnErrorSampleRate: 0,
+        replaysSessionSampleRate: 0,
+        beforeSend: sanitizeSentryEvent,
+    });
+
+    return true;
+}

--- a/ui/tests/sentry.jsx
+++ b/ui/tests/sentry.jsx
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { captureException, init } = vi.hoisted(() => ({
+    captureException: vi.fn(),
+    init: vi.fn(),
+}));
+
+vi.mock("@sentry/react", () => ({ captureException, init }));
+
+import RouteErrorBoundary from "@/components/RouteErrorBoundary.jsx";
+import { initializeSentry, sanitizeSentryEvent } from "@/sentry";
+
+function ThrowError() {
+    throw new Error("sensitive callsign data");
+}
+
+describe("Sentry error reporting", () => {
+    afterEach(() => {
+        cleanup();
+        captureException.mockReset();
+        init.mockReset();
+        vi.restoreAllMocks();
+    });
+
+    it("does not initialize without a DSN", () => {
+        expect(initializeSentry({ dsn: undefined })).toBe(false);
+        expect(init).not.toHaveBeenCalled();
+    });
+
+    it("disables tracing and replay when configured", () => {
+        expect(
+            initializeSentry({
+                dsn: "https://public@example.ingest.sentry.io/1",
+                environment: "production",
+                release: "abcdef",
+            }),
+        ).toBe(true);
+
+        expect(init).toHaveBeenCalledWith(
+            expect.objectContaining({
+                dsn: "https://public@example.ingest.sentry.io/1",
+                environment: "production",
+                release: "abcdef",
+                sendDefaultPii: false,
+                tracesSampleRate: 0,
+                replaysOnErrorSampleRate: 0,
+                replaysSessionSampleRate: 0,
+            }),
+        );
+    });
+
+    it("removes sensitive event data before sending", () => {
+        const event = sanitizeSentryEvent({
+            breadcrumbs: [{ message: "K1ABC" }],
+            contexts: { profile: { callsign: "K1ABC" } },
+            exception: { values: [{ value: "K1ABC failed" }] },
+            extra: { callsign: "K1ABC" },
+            request: { headers: { authorization: "secret" } },
+            user: { email: "operator@example.com" },
+        });
+
+        expect(event).not.toHaveProperty("breadcrumbs");
+        expect(event).not.toHaveProperty("contexts");
+        expect(event).not.toHaveProperty("extra");
+        expect(event).not.toHaveProperty("request");
+        expect(event).not.toHaveProperty("user");
+        expect(event.exception.values[0].value).toBe("Application error");
+    });
+
+    it("shows the fallback and reports a rendering failure", () => {
+        vi.spyOn(console, "error").mockImplementation(() => {});
+
+        render(
+            <RouteErrorBoundary>
+                <ThrowError />
+            </RouteErrorBoundary>,
+        );
+
+        expect(screen.getByRole("alert").textContent).toContain("Something went wrong");
+        expect(captureException).toHaveBeenCalledWith(expect.any(Error));
+    });
+});

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,10 +1,31 @@
 import path from "node:path";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { ctyDxccEntitiesPlugin } from "./scripts/cty_entities.js";
 
-export default defineConfig({
-    plugins: [ctyDxccEntitiesPlugin(), react()],
+const sentry_options = {
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    org: process.env.SENTRY_ORG,
+    project: process.env.SENTRY_PROJECT,
+    release: {
+        name: process.env.SENTRY_RELEASE,
+    },
+};
+
+const sentry_upload_enabled = Object.values({
+    authToken: sentry_options.authToken,
+    org: sentry_options.org,
+    project: sentry_options.project,
+    release: sentry_options.release.name,
+}).every(Boolean);
+
+export default defineConfig(({ mode }) => ({
+    plugins: [
+        ctyDxccEntitiesPlugin(),
+        react(),
+        ...(sentry_upload_enabled ? [sentryVitePlugin(sentry_options)] : []),
+    ],
     worker: {
         plugins: () => [ctyDxccEntitiesPlugin()],
     },
@@ -45,6 +66,7 @@ export default defineConfig({
         },
     },
     build: {
+        sourcemap: mode === "production" ? "hidden" : false,
         rollupOptions: {
             output: {
                 manualChunks: id => {
@@ -62,4 +84,4 @@ export default defineConfig({
             },
         },
     },
-});
+}));


### PR DESCRIPTION
## Summary
- initialize Sentry only when a DSN is configured, with PII stripping and tracing/replay disabled
- add a route-level React error fallback and coverage for reporting behavior
- upload hidden production source maps in CI and remove them before deployment

Closes #360

## Tests
- `cd ui && npx biome check .`
- `cd ui && npm test`
- `cd ui && npm run build`
- verified generated maps are removed by the deployment cleanup command

## Risks / follow-up
- Source-map uploads activate only after the Sentry GitHub variables and auth-token secret are configured.