### PR TITLE
Add backend Sentry error reporting

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,11 @@
 # general
 LOG_DIR=/var/log/holy
 
+# Sentry (optional)
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=production
+SENTRY_RELEASE=
+
 # postgres
 POSTGRES_USER=
 POSTGRES_PASSWORD=

--- a/backend/api/src/api/main.py
+++ b/backend/api/src/api/main.py
@@ -20,6 +20,7 @@ from shared.cty import ensure_cty_available
 from shared.db import GeoCache, HolySpot, PropagationMeasurement, SpotsWithIssues
 from shared.geo import GeoException, get_geo_details
 from shared.metrics import push_exception_event, set_timestamp, set_value
+from shared.telemetry import capture_exception, initialize_sentry
 from sqlalchemy import desc, func
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -28,6 +29,8 @@ from sqlmodel import select
 
 from . import propagation, submit_spot, voacap
 from .settings import settings
+
+initialize_sentry(settings, "api")
 
 
 def build_propagation_measurement_rows(history, collected_at):
@@ -86,10 +89,12 @@ async def propagation_data_collector(app):
             except Exception as e:
                 sleep = 10
                 logger.exception(f"Failed to persist propagation data: {str(e)}")
+                capture_exception(e)
                 await push_exception_event(app.state.valkey_client, "api", f"propagation persist: {e}")
         except Exception as e:
             sleep = 10
             logger.exception(f"Failed to fetch propagation data: {str(e)}")
+            capture_exception(e)
             await push_exception_event(app.state.valkey_client, "api", f"propagation: {e}")
         await asyncio.sleep(sleep)
 
@@ -163,6 +168,7 @@ async def spots_broadcast_task(app):
 
         except Exception as e:
             logger.exception(f"Error in spots broadcast task: {e}")
+            capture_exception(e)
             await push_exception_event(valkey_client, "api", f"broadcast: {e}")
 
 

--- a/backend/api/src/api/settings.py
+++ b/backend/api/src/api/settings.py
@@ -3,10 +3,10 @@ from pathlib import Path
 
 from pydantic import Field, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from shared.settings import LogSettings, PostgresSettings, QrzSettings, ValkeySettings
+from shared.settings import LogSettings, PostgresSettings, QrzSettings, SentrySettings, ValkeySettings
 
 
-class ApiSettings(PostgresSettings, ValkeySettings, QrzSettings, LogSettings, BaseSettings):
+class ApiSettings(PostgresSettings, ValkeySettings, QrzSettings, LogSettings, SentrySettings, BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/backend/api/src/api/submit_spot.py
+++ b/backend/api/src/api/submit_spot.py
@@ -6,6 +6,7 @@ from loguru import logger
 
 from api.settings import settings
 from shared.metrics import push_exception_event
+from shared.telemetry import capture_exception
 
 CLUSTER_HOST = "dxc.ai9t.com"
 CLUSTER_PORT = 7300
@@ -279,6 +280,7 @@ async def handle_spot(data, valkey: redis.asyncio.Redis):
             response["phase"] = e.phase
         if should_alert_submit_failure(e):
             logger.exception(f"Failed to submit spot: {data}, Response: {response}")
+            capture_exception(e)
             await push_exception_event(valkey, "submit_spot", f"{e.__class__.__name__}: {e}, Spot: {data}")
         else:
             logger.warning(f"Spot submit failure not alerting monitor: {data}, Response: {response}")

--- a/backend/api/tests/test_submit_spot_telemetry.py
+++ b/backend/api/tests/test_submit_spot_telemetry.py
@@ -1,0 +1,22 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from api import submit_spot
+
+
+class SubmitSpotTelemetryTest(IsolatedAsyncioTestCase):
+    async def test_unexpected_submit_failure_reports_to_sentry_and_monitor(self):
+        error = RuntimeError("cluster rejected K1ABC from FN31")
+        monitor_event = AsyncMock()
+        captured = []
+
+        with (
+            patch("api.submit_spot.submit_spot_with_retries", side_effect=error),
+            patch("api.submit_spot.capture_exception", side_effect=captured.append),
+            patch("api.submit_spot.push_exception_event", monitor_event),
+        ):
+            response = await submit_spot.handle_spot({"dx_callsign": "K1ABC", "frequency": 14074}, object())
+
+        self.assertEqual(response["status"], "failure")
+        self.assertEqual(captured, [error])
+        monitor_event.assert_awaited_once()

--- a/backend/collectors/src/collectors/main.py
+++ b/backend/collectors/src/collectors/main.py
@@ -11,6 +11,7 @@ from shared.db import HolySpot
 from shared.geo import GeoException, get_geo_details
 from shared.metrics import push_drop_event, push_exception_event, set_timestamp
 from shared.qrz import QrzSessionManager
+from shared.telemetry import capture_exception, initialize_sentry
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 from collectors.db.valkey_config import get_valkey_client
@@ -199,6 +200,7 @@ async def process_spots(input_queue: asyncio.Queue, qrz_manager: QrzSessionManag
                     continue
                 except Exception as e:
                     logger.exception("Unexpected error enriching spot")
+                    capture_exception(e)
                     await push_exception_event(valkey_client, "collector", str(e))
                     continue
 
@@ -235,6 +237,7 @@ async def refresh_dxpedition_data(valkey_client):
         except Exception as e:
             sleep = 600
             logger.exception("Failed to refresh DXpedition data")
+            capture_exception(e)
             await push_exception_event(valkey_client, "collector", f"dxpedition refresh: {e}")
         await asyncio.sleep(sleep)
 
@@ -253,6 +256,7 @@ async def refresh_lotw_user_data(valkey_client):
             await update_lotw_user_data()
         except Exception as e:
             logger.exception("Failed to refresh LoTW user activity")
+            capture_exception(e)
             await push_exception_event(valkey_client, "collector", f"LoTW refresh: {e}")
             sleep = 600
         await asyncio.sleep(sleep)
@@ -326,6 +330,7 @@ def main():
         logger.remove()
         logger.add(sys.stdout, level="INFO", filter=lambda record: "task" not in record["extra"])
 
+    initialize_sentry(settings, "collector")
     asyncio.run(run_collector_with_monitor())
 
 

--- a/backend/collectors/src/collectors/settings.py
+++ b/backend/collectors/src/collectors/settings.py
@@ -1,9 +1,9 @@
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from shared.settings import LogSettings, PostgresSettings, QrzSettings, ValkeySettings
+from shared.settings import LogSettings, PostgresSettings, QrzSettings, SentrySettings, ValkeySettings
 
 
-class CollectorsSettings(PostgresSettings, ValkeySettings, QrzSettings, LogSettings, BaseSettings):
+class CollectorsSettings(PostgresSettings, ValkeySettings, QrzSettings, LogSettings, SentrySettings, BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/backend/collectors/src/collectors/telnet/client.py
+++ b/backend/collectors/src/collectors/telnet/client.py
@@ -5,6 +5,7 @@ import re
 
 from loguru import logger
 from shared.metrics import push_drop_event, push_exception_event, set_value
+from shared.telemetry import capture_exception
 
 from collectors.db.valkey_config import get_valkey_client
 from collectors.logging_setup import open_task_log_file
@@ -160,6 +161,7 @@ async def telnet_and_collect(
             task_logger.exception(f"Connection failed: {host}:{port}  {e}")
             logger.exception(f"Connection failed: {host}:{port}  {e}")
             await set_value(valkey_client, f"collector:telnet:{host}:connected", 0)
+            capture_exception(e)
             await push_exception_event(valkey_client, "collector", f"telnet {host}:{port}: {e}")
 
         except asyncio.CancelledError:

--- a/backend/collectors/src/collectors/utils.py
+++ b/backend/collectors/src/collectors/utils.py
@@ -6,6 +6,7 @@ from typing import Any
 import aiohttp
 from loguru import logger
 from shared.metrics import push_drop_event, push_exception_event, set_value
+from shared.telemetry import capture_exception
 
 STREAM_ARRIVALS = "stream-arrivals"
 USER_AGENT = "HolyCluster collector (https://holycluster.iarc.org/)"
@@ -106,5 +107,6 @@ async def run_json_spot_collector(
             except Exception as e:
                 logger.exception(f"{source_label} collector failed")
                 await set_value(valkey_client, connected_key, 0)
+                capture_exception(e)
                 await push_exception_event(valkey_client, "collector", f"{metric_name}: {e}")
                 await asyncio.sleep(min(poll_interval, 300))

--- a/backend/collectors/tests/test_collector_telemetry.py
+++ b/backend/collectors/tests/test_collector_telemetry.py
@@ -1,0 +1,59 @@
+import asyncio
+import os
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from collectors import utils
+
+SETTINGS_ENV = {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "test",
+    "POSTGRES_PORT": "1",
+    "POSTGRES_HOST_LOCAL": "test",
+    "POSTGRES_PORT_LOCAL": "1",
+    "QRZ_USER": "test",
+    "QRZ_PASSWORD": "test",
+    "QRZ_API_KEY": "test",
+    "VALKEY_HOST": "test",
+    "VALKEY_PORT": "1",
+    "VALKEY_HOST_LOCAL": "test",
+    "VALKEY_PORT_LOCAL": "1",
+    "USERNAME_FOR_TELNET_CLUSTERS": "test",
+}
+
+
+class JsonCollectorTelemetryTest(IsolatedAsyncioTestCase):
+    async def test_poll_failure_reports_to_sentry_and_monitor(self):
+        error = RuntimeError("source failed for K1ABC at FN31")
+        valkey_client = object()
+        monitor_event = AsyncMock()
+        captured = []
+
+        with (
+            patch.dict(os.environ, SETTINGS_ENV, clear=True),
+            patch("collectors.db.valkey_config.get_valkey_client", return_value=valkey_client),
+            patch("collectors.utils.fetch_json_list", side_effect=error),
+            patch("collectors.utils.set_value", AsyncMock()) as set_value,
+            patch("collectors.utils.capture_exception", side_effect=captured.append),
+            patch("collectors.utils.push_exception_event", monitor_event),
+            patch("collectors.utils.asyncio.sleep", side_effect=asyncio.CancelledError),
+        ):
+            with self.assertRaises(asyncio.CancelledError):
+                await utils.run_json_spot_collector(
+                    asyncio.Queue(),
+                    source_label="test",
+                    metric_name="test",
+                    cluster="test",
+                    url="https://example.invalid/spots",
+                    poll_interval=1,
+                    request_timeout=1,
+                    spot_expiration=1,
+                    get_spot_key=lambda spot: "test",
+                    parse_spot=lambda spot: spot,
+                    sort_key=lambda spot: 0,
+                )
+
+        set_value.assert_awaited_once_with(valkey_client, "collector:test:connected", 0)
+        self.assertEqual(captured, [error])
+        monitor_event.assert_awaited_once_with(valkey_client, "collector", "test: source failed for K1ABC at FN31")

--- a/backend/shared/pyproject.toml
+++ b/backend/shared/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-settings>=2.7.1",
     "redis>=7.1.0",
     "sqlmodel>=0.0.27",
+    "sentry-sdk>=2.0.0",
 ]
 
 [project.scripts]

--- a/backend/shared/src/shared/settings.py
+++ b/backend/shared/src/shared/settings.py
@@ -88,6 +88,19 @@ class LogSettings(BaseSettings):
     log_dir: str = Field(default="/var/log/holy", description="Root directory for all log files")
 
 
+class SentrySettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    sentry_dsn: str | None = Field(default=None, description="Sentry DSN")
+    sentry_environment: str = Field(default="production", description="Sentry environment")
+    sentry_release: str | None = Field(default=None, description="Sentry release")
+
+
 class QrzSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/backend/shared/src/shared/telemetry.py
+++ b/backend/shared/src/shared/telemetry.py
@@ -12,6 +12,8 @@ SENSITIVE_KEY_PARTS = (
     "cookie",
     "credential",
     "locator",
+    "latitude",
+    "longitude",
     "password",
     "raw_spot",
     "radio",
@@ -53,7 +55,12 @@ def scrub_event(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any]:
     event.pop("contexts", None)
     event.pop("request", None)
     event.pop("user", None)
-    return scrub_value(event)
+    scrubbed = scrub_value(event)
+    for value in scrubbed.get("exception", {}).get("values", []):
+        value["value"] = REDACTED
+        for frame in value.get("stacktrace", {}).get("frames", []):
+            frame.pop("vars", None)
+    return scrubbed
 
 
 def initialize_sentry(settings: SentrySettings, service: str):

--- a/backend/shared/src/shared/telemetry.py
+++ b/backend/shared/src/shared/telemetry.py
@@ -1,0 +1,79 @@
+import re
+from collections.abc import Mapping
+from typing import Any
+
+import sentry_sdk
+
+from .settings import SentrySettings
+
+SENSITIVE_KEY_PARTS = (
+    "authorization",
+    "callsign",
+    "cookie",
+    "credential",
+    "locator",
+    "password",
+    "raw_spot",
+    "radio",
+    "secret",
+    "spotter",
+    "token",
+)
+CALLSIGN_PATTERN = re.compile(r"\b[A-Z]{1,3}\d[A-Z0-9/]{0,7}\b", re.IGNORECASE)
+LOCATOR_PATTERN = re.compile(r"\b[A-R]{2}\d{2}(?:[A-X]{2}){0,2}\b", re.IGNORECASE)
+URL_QUERY_PATTERN = re.compile(r"\?[^\s]+")
+REDACTED = "[Filtered]"
+enabled = False
+
+
+def is_sensitive_key(key: object) -> bool:
+    return any(part in str(key).lower() for part in SENSITIVE_KEY_PARTS)
+
+
+def scrub_text(value: str) -> str:
+    value = URL_QUERY_PATTERN.sub("", value)
+    value = CALLSIGN_PATTERN.sub(REDACTED, value)
+    return LOCATOR_PATTERN.sub(REDACTED, value)
+
+
+def scrub_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: REDACTED if is_sensitive_key(key) else scrub_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [scrub_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(scrub_value(item) for item in value)
+    if isinstance(value, str):
+        return scrub_text(value)
+    return value
+
+
+def scrub_event(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any]:
+    event.pop("breadcrumbs", None)
+    event.pop("contexts", None)
+    event.pop("request", None)
+    event.pop("user", None)
+    return scrub_value(event)
+
+
+def initialize_sentry(settings: SentrySettings, service: str):
+    global enabled
+    enabled = bool(settings.sentry_dsn)
+    if not settings.sentry_dsn:
+        return None
+
+    return sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.sentry_environment,
+        release=settings.sentry_release,
+        send_default_pii=False,
+        include_local_variables=False,
+        max_breadcrumbs=0,
+        before_send=scrub_event,
+        initial_scope={"tags": {"service": service}},
+    )
+
+
+def capture_exception(error: BaseException) -> None:
+    if enabled:
+        sentry_sdk.capture_exception(error)

--- a/backend/shared/tests/test_telemetry.py
+++ b/backend/shared/tests/test_telemetry.py
@@ -1,0 +1,39 @@
+from shared.settings import SentrySettings
+from shared.telemetry import REDACTED, capture_exception, initialize_sentry, scrub_event
+
+
+def test_initialize_sentry_is_disabled_without_dsn(monkeypatch):
+    called = False
+
+    def sentry_init(**kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("shared.telemetry.sentry_sdk.init", sentry_init)
+    monkeypatch.setattr("shared.telemetry.sentry_sdk.capture_exception", sentry_init)
+
+    assert initialize_sentry(SentrySettings(), "api") is None
+    capture_exception(ValueError("not reported"))
+    assert not called
+
+
+def test_scrub_event_removes_request_data_and_sensitive_values():
+    event = {
+        "request": {"data": "raw spot", "query_string": "callsign=K1ABC"},
+        "breadcrumbs": [{"message": "radio configuration"}],
+        "contexts": {"radio": {"frequency": "14074"}},
+        "extra": {
+            "raw_spot": {"dx_callsign": "K1ABC"},
+            "message": "Failed for K1ABC at FN31 with ?callsign=K1ABC",
+        },
+        "exception": {"values": [{"value": "K1ABC at FN31"}]},
+    }
+
+    scrubbed = scrub_event(event, {})
+
+    assert "request" not in scrubbed
+    assert "breadcrumbs" not in scrubbed
+    assert "contexts" not in scrubbed
+    assert scrubbed["extra"]["raw_spot"] == REDACTED
+    assert scrubbed["extra"]["message"] == f"Failed for {REDACTED} at {REDACTED} with "
+    assert scrubbed["exception"]["values"][0]["value"] == f"{REDACTED} at {REDACTED}"

--- a/backend/shared/tests/test_telemetry.py
+++ b/backend/shared/tests/test_telemetry.py
@@ -17,6 +17,24 @@ def test_initialize_sentry_is_disabled_without_dsn(monkeypatch):
     assert not called
 
 
+def test_initialize_sentry_sets_service_and_release_metadata(monkeypatch):
+    captured = {}
+
+    def sentry_init(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("shared.telemetry.sentry_sdk.init", sentry_init)
+
+    initialize_sentry(
+        SentrySettings(sentry_dsn="https://key@example.invalid/1", sentry_environment="staging", sentry_release="v1"),
+        "collector",
+    )
+
+    assert captured["environment"] == "staging"
+    assert captured["release"] == "v1"
+    assert captured["initial_scope"] == {"tags": {"service": "collector"}}
+
+
 def test_scrub_event_removes_request_data_and_sensitive_values():
     event = {
         "request": {"data": "raw spot", "query_string": "callsign=K1ABC"},
@@ -36,4 +54,4 @@ def test_scrub_event_removes_request_data_and_sensitive_values():
     assert "contexts" not in scrubbed
     assert scrubbed["extra"]["raw_spot"] == REDACTED
     assert scrubbed["extra"]["message"] == f"Failed for {REDACTED} at {REDACTED} with "
-    assert scrubbed["exception"]["values"][0]["value"] == f"{REDACTED} at {REDACTED}"
+    assert scrubbed["exception"]["values"][0]["value"] == REDACTED

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1284,6 +1284,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.66.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/6f/d59cad0889d15fde85254cf58e701484de3f3f0406003b3197746910b19b/sentry_sdk-2.66.1.tar.gz", hash = "sha256:f882fb08710c5f8bfc603aafa3e901b384009a19cc3f76a572b863392ee81cdc", size = 940543, upload-time = "2026-07-22T12:26:54.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/d3/726bd88f0eece09ddf431bea4c9191c18e7a8d070b854eb0014d447712ee/sentry_sdk-2.66.1-py3-none-any.whl", hash = "sha256:86002793161d9a95ef04bdd8d442e9bfece5d989b755f05d6360215094a7aff6", size = 505555, upload-time = "2026-07-22T12:26:52.71Z" },
+]
+
+[[package]]
 name = "shared"
 version = "0.1.0"
 source = { editable = "shared" }
@@ -1295,6 +1308,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "redis" },
+    { name = "sentry-sdk" },
     { name = "sqlmodel" },
 ]
 
@@ -1307,6 +1321,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "redis", specifier = ">=7.1.0" },
+    { name = "sentry-sdk", specifier = ">=2.0.0" },
     { name = "sqlmodel", specifier = ">=0.0.27" },
 ]
 
@@ -1425,6 +1440,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add shared opt-in Sentry initialization for API and collectors
- preserve Valkey monitor events while reporting unexpected failures to Sentry
- scrub request, credentials, spot, callsign, locator, and radio-related telemetry data

## Tests
- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest`

Closes #360

## Risks
- Sentry remains disabled unless `SENTRY_DSN` is configured.