### PR TITLE
Add missing section alert toggles

### DIFF
--- a/ui/src/components/MissingPanel.jsx
+++ b/ui/src/components/MissingPanel.jsx
@@ -1,6 +1,7 @@
 import Button from "@/components/ui/Button.jsx";
 import Modal from "@/components/ui/Modal.jsx";
 import SearchIcon from "@/components/ui/SearchIcon.jsx";
+import Toggle from "@/components/ui/Toggle.jsx";
 import { dxcc_codes, get_dxcc_label } from "@/data/dxcc_entities.js";
 import {
     MISSING_SECTION_KEYS,
@@ -8,6 +9,7 @@ import {
 } from "@/data/missing_sections.js";
 import { STATES } from "@/data/states.js";
 import { useColors } from "@/hooks/useColors";
+import { useFilters } from "@/hooks/useFilters";
 import { useProfiles } from "@/hooks/useProfiles.jsx";
 import { MISSING_ADIF_MAX_FILE_SIZE_BYTES, MISSING_IMPORT_PHASES } from "@/utils/missing_adif.js";
 import { import_missing_adif_in_worker } from "@/utils/missing_adif_worker_client.js";
@@ -224,7 +226,15 @@ function SectionStats({ worked_count, needed_count, total_count }) {
     );
 }
 
-function MissingSectionCard({ section, items, missing, colors, on_apply_section }) {
+function MissingSectionCard({
+    section,
+    items,
+    missing,
+    colors,
+    is_alert_filter_active,
+    on_toggle_alert_filter,
+    on_apply_section,
+}) {
     const worked_values = missing.worked[section]?.global ?? [];
     const { worked_count, needed_count, is_section_complete } = get_section_progress(
         items,
@@ -247,6 +257,7 @@ function MissingSectionCard({ section, items, missing, colors, on_apply_section 
                         total_count={items.length}
                     />
                 </div>
+                <Toggle value={is_alert_filter_active} on_click={on_toggle_alert_filter} />
             </div>
 
             {is_section_complete ? (
@@ -584,6 +595,7 @@ export default function MissingPanel({ on_import_complete = null }) {
         active_profile_data: { missing },
         update_active_profile_section,
     } = useProfiles();
+    const { callsign_filters, setCallsignFilters } = useFilters();
     const [import_error, set_import_error] = useState("");
     const [is_importing, set_is_importing] = useState(false);
     const [import_progress, set_import_progress] = useState(null);
@@ -604,6 +616,39 @@ export default function MissingPanel({ on_import_complete = null }) {
                 },
             },
         }));
+    }
+
+    function is_alert_filter_active(section) {
+        return callsign_filters.filters.some(
+            filter =>
+                filter.action === "alert" &&
+                filter.type === "missing" &&
+                filter.missing_section === section,
+        );
+    }
+
+    function toggle_alert_filter(section) {
+        setCallsignFilters(current => {
+            const is_active = current.filters.some(
+                filter =>
+                    filter.action === "alert" &&
+                    filter.type === "missing" &&
+                    filter.missing_section === section,
+            );
+            const filters = is_active
+                ? current.filters.filter(
+                      filter =>
+                          filter.action !== "alert" ||
+                          filter.type !== "missing" ||
+                          filter.missing_section !== section,
+                  )
+                : [
+                      ...current.filters,
+                      { action: "alert", type: "missing", missing_section: section },
+                  ];
+
+            return { ...current, filters };
+        });
     }
 
     async function handle_import_file(event) {
@@ -742,6 +787,8 @@ export default function MissingPanel({ on_import_complete = null }) {
                     items={section_items[section]}
                     missing={missing}
                     colors={colors}
+                    is_alert_filter_active={is_alert_filter_active(section)}
+                    on_toggle_alert_filter={() => toggle_alert_filter(section)}
                     on_apply_section={apply_section}
                 />
             ))}

--- a/ui/src/components/SidePanel.jsx
+++ b/ui/src/components/SidePanel.jsx
@@ -12,7 +12,7 @@ import { continents } from "@/data/filters_data.js";
 import { useColors } from "@/hooks/useColors";
 import { useFilters } from "@/hooks/useFilters";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 const continent_title = { dx: "DX", spotter: "DE" };
 
@@ -255,7 +255,6 @@ function ViewSelectorTabs({ active_view, set_active_view, colors, dev_mode }) {
 
 function SidePanel({ toggled_ui, set_toggled_ui, set_cat_to_spot, active_view, set_active_view }) {
     const { colors, dev_mode } = useColors();
-    const [open_import_filter, set_open_import_filter] = useState(false);
 
     useEffect(() => {
         function select_tab(event) {
@@ -275,15 +274,10 @@ function SidePanel({ toggled_ui, set_toggled_ui, set_cat_to_spot, active_view, s
     function handle_import_complete() {
         set_toggled_ui(state => ({ ...state, right_visible: true }));
         set_active_view(0);
-        set_open_import_filter(true);
     }
 
     const content = [
-        <Filters
-            key="filters"
-            open_import_filter={open_import_filter}
-            on_import_filter_open={() => set_open_import_filter(false)}
-        />,
+        <Filters key="filters" />,
         <FrequencyBar
             key="frequency-bar"
             set_cat_to_spot={set_cat_to_spot}

--- a/ui/src/components/SidePanel.jsx
+++ b/ui/src/components/SidePanel.jsx
@@ -273,7 +273,6 @@ function SidePanel({ toggled_ui, set_toggled_ui, set_cat_to_spot, active_view, s
 
     function handle_import_complete() {
         set_toggled_ui(state => ({ ...state, right_visible: true }));
-        set_active_view(0);
     }
 
     const content = [

--- a/ui/tests/missing_panel.jsx
+++ b/ui/tests/missing_panel.jsx
@@ -27,6 +27,7 @@ vi.mock("virtual:cty-dxcc-entities", () => ({
 
 import MissingPanel from "@/components/MissingPanel.jsx";
 import { ColorsProvider } from "@/hooks/useColors.jsx";
+import { FiltersProvider } from "@/hooks/useFilters.jsx";
 import { ProfilesProvider } from "@/hooks/useProfiles.jsx";
 import {
     PROFILE_STORE_KEY,
@@ -48,7 +49,9 @@ function render_missing_panel(profile_data = create_default_profile_data(), prop
         <MemoryRouter>
             <ProfilesProvider>
                 <ColorsProvider>
-                    <MissingPanel {...props} />
+                    <FiltersProvider>
+                        <MissingPanel {...props} />
+                    </FiltersProvider>
                 </ColorsProvider>
             </ProfilesProvider>
         </MemoryRouter>,
@@ -87,7 +90,45 @@ describe("MissingPanel", () => {
         const dxcc_section = section_by_heading("DXCC");
         expect_section_stats(dxcc_section, { worked: 0, needed: 4, total: 4 });
         expect(within(dxcc_section).getByRole("button", { name: "Edit" })).toBeTruthy();
-        expect(within(dxcc_section).queryByRole("switch")).toBeNull();
+        expect(within(dxcc_section).getByRole("switch", { checked: false })).toBeTruthy();
+    });
+
+    it("synchronizes section alert toggles with missing alert filters", async () => {
+        const user = userEvent.setup();
+        const profile_data = create_default_profile_data();
+        profile_data.callsign_filters.filters.push({
+            action: "alert",
+            type: "missing",
+            missing_section: "cq_zone",
+        });
+        render_missing_panel(profile_data);
+
+        const dxcc_toggle = within(section_by_heading("DXCC")).getByRole("switch");
+        const cq_toggle = within(section_by_heading("CQ")).getByRole("switch");
+        expect(dxcc_toggle.getAttribute("aria-checked")).toBe("false");
+        expect(cq_toggle.getAttribute("aria-checked")).toBe("true");
+
+        await user.click(dxcc_toggle);
+        await waitFor(() => {
+            expect(dxcc_toggle.getAttribute("aria-checked")).toBe("true");
+            const stored_profiles = JSON.parse(window.localStorage.getItem(PROFILE_STORE_KEY));
+            expect(stored_profiles.profiles[0].data.callsign_filters.filters).toEqual(
+                expect.arrayContaining([
+                    { action: "alert", type: "missing", missing_section: "dxcc" },
+                ]),
+            );
+        });
+
+        await user.click(cq_toggle);
+        await waitFor(() => {
+            expect(cq_toggle.getAttribute("aria-checked")).toBe("false");
+            const stored_profiles = JSON.parse(window.localStorage.getItem(PROFILE_STORE_KEY));
+            expect(stored_profiles.profiles[0].data.callsign_filters.filters).not.toEqual(
+                expect.arrayContaining([
+                    { action: "alert", type: "missing", missing_section: "cq_zone" },
+                ]),
+            );
+        });
     });
 
     it("opens a section edit modal", async () => {

--- a/ui/tests/side_panel.jsx
+++ b/ui/tests/side_panel.jsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { MemoryRouter } from "react-router";
@@ -77,10 +77,6 @@ function render_side_panel() {
     );
 }
 
-function expect_selected(dialog, data_tour) {
-    expect(dialog.querySelector(`[data-tour="${data_tour}"]`).className).toContain("bg-green-600");
-}
-
 describe("SidePanel", () => {
     beforeEach(() => {
         window.localStorage.clear();
@@ -91,26 +87,17 @@ describe("SidePanel", () => {
         window.localStorage.clear();
     });
 
-    it("opens a preselected missing DXCC alert filter after an import", async () => {
+    it("shows the Filters panel without opening a filter modal after an import", async () => {
         const user = userEvent.setup();
         render_side_panel();
 
         expect(screen.getByTestId("right-panel-state").textContent).toBe("closed");
         await user.click(screen.getByRole("button", { name: "Complete import" }));
 
-        const dialog = await screen.findByRole("dialog");
         expect(screen.getByTestId("right-panel-state").textContent).toBe("open");
         expect(screen.getByRole("button", { name: "Filters" }).getAttribute("aria-pressed")).toBe(
             "true",
         );
-        expect_selected(dialog, "filter-modal-action-alert");
-        expect_selected(dialog, "filter-modal-type-missing");
-        expect_selected(dialog, "filter-modal-missing-section-dxcc");
-
-        await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
-        await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
-        await user.click(screen.getByRole("button", { name: "Missing" }));
-        await user.click(screen.getByRole("button", { name: "Filters" }));
         expect(screen.queryByRole("dialog")).toBeNull();
     });
 });

--- a/ui/tests/side_panel.jsx
+++ b/ui/tests/side_panel.jsx
@@ -87,7 +87,7 @@ describe("SidePanel", () => {
         window.localStorage.clear();
     });
 
-    it("shows the Filters panel without opening a filter modal after an import", async () => {
+    it("keeps the Missing panel open without opening a filter modal after an import", async () => {
         const user = userEvent.setup();
         render_side_panel();
 
@@ -95,7 +95,7 @@ describe("SidePanel", () => {
         await user.click(screen.getByRole("button", { name: "Complete import" }));
 
         expect(screen.getByTestId("right-panel-state").textContent).toBe("open");
-        expect(screen.getByRole("button", { name: "Filters" }).getAttribute("aria-pressed")).toBe(
+        expect(screen.getByRole("button", { name: "Missing" }).getAttribute("aria-pressed")).toBe(
             "true",
         );
         expect(screen.queryByRole("dialog")).toBeNull();


### PR DESCRIPTION
## Summary
- add an Alert toggle to every Missing section card
- synchronize each card with its matching alert/missing filter
- cover persisted filter synchronization in MissingPanel tests

Closes #353

## Tests
- `npm test -- tests/missing_panel.jsx`
- `npx biome check src/components/MissingPanel.jsx tests/missing_panel.jsx`
- `npm run check` *(fails in existing `tests/update_controls.jsx`: expected button name "Update", rendered "Install update")*