### PR TITLE
ci: deploy backend and UI to the int server on push to int

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/backend.yml"
     branches:
       - "dev"
+      - "int"
     tags:
       - "backend-v*"
   pull_request:
@@ -15,12 +16,13 @@ on:
       - ".github/workflows/backend.yml"
     branches:
       - "dev"
+      - "int"
 
 jobs:
   build-and-deploy-backend:
     name: Lint and Deploy Backend
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/backend-v')
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/int' || startsWith(github.ref, 'refs/tags/backend-v')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,12 +60,13 @@ jobs:
           uv run pytest
 
       - name: Setup SSH
-        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/backend-v')
+        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/int' || startsWith(github.ref, 'refs/tags/backend-v')
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST_DEV }} >> ~/.ssh/known_hosts
+          ssh-keyscan -H ${{ secrets.DEPLOY_HOST_INT }} >> ~/.ssh/known_hosts
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST_PROD }} >> ~/.ssh/known_hosts
 
       - name: Deploy to Development Server
@@ -71,6 +74,12 @@ jobs:
         run: |
           ssh ${{ secrets.DEPLOY_USER_DEV }}@${{ secrets.DEPLOY_HOST_DEV }} \
             "cd ${{ secrets.REPO_ROOT_DEV }} && git fetch && git checkout origin/dev -- backend/deploy.sh && cd backend && bash deploy.sh origin/dev"
+
+      - name: Deploy to Integration Server
+        if: github.ref == 'refs/heads/int'
+        run: |
+          ssh ${{ secrets.DEPLOY_USER_INT }}@${{ secrets.DEPLOY_HOST_INT }} \
+            "cd ${{ secrets.REPO_ROOT_INT }} && git fetch && git checkout origin/int -- backend/deploy.sh && cd backend && bash deploy.sh origin/int"
 
       - name: Deploy to Production Server
         if: startsWith(github.ref, 'refs/tags/backend-v')

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/ui.yml"
     branches:
       - "dev"
+      - "int"
     tags:
       - "v*"
   pull_request:
@@ -15,12 +16,13 @@ on:
       - ".github/workflows/ui.yml"
     branches:
       - "dev"
+      - "int"
 
 jobs:
   build-and-deploy-ui:
     name: Build, Lint, and Deploy the UI
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/int' || startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -53,18 +55,24 @@ jobs:
           npm run build
 
       - name: Setup SSH
-        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/int' || startsWith(github.ref, 'refs/tags/')
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST_DEV }} >> ~/.ssh/known_hosts
+          ssh-keyscan -H ${{ secrets.DEPLOY_HOST_INT }} >> ~/.ssh/known_hosts
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST_PROD }} >> ~/.ssh/known_hosts
 
       - name: Upload to Development Server
         if: github.ref == 'refs/heads/dev'
         run: |
           rsync -avz --delete ui/dist/ ${{ secrets.DEPLOY_USER_DEV }}@${{ secrets.DEPLOY_HOST_DEV }}:${{ secrets.DEPLOY_PATH_DEV }}/
+
+      - name: Upload to Integration Server
+        if: github.ref == 'refs/heads/int'
+        run: |
+          rsync -avz --delete ui/dist/ ${{ secrets.DEPLOY_USER_INT }}@${{ secrets.DEPLOY_HOST_INT }}:${{ secrets.DEPLOY_PATH_INT }}/
 
       - name: Upload to Production Server
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Why

The `int` branch had no CI at all. Both workflows triggered only on `dev` and on tags, so pushing to `int` ran nothing and there was no integration environment to exercise a change before a release tag shipped it to prod.

## What

Mirrors the existing `dev` wiring in `backend.yml` and `ui.yml` rather than inventing a new shape, so the three environments stay symmetric:

- `int` added to `push.branches`, `pull_request.branches`, and the job-level `if` guards
- `DEPLOY_HOST_INT` added to `ssh-keyscan`
- one deploy step per workflow, gated on `github.ref == 'refs/heads/int'`

Backend runs `deploy.sh origin/int` on the int box. UI rsyncs `ui/dist/` to `DEPLOY_PATH_INT`.

## Secrets

Four new repo-level secrets are already set: `DEPLOY_HOST_INT`, `DEPLOY_USER_INT`, `REPO_ROOT_INT`, `DEPLOY_PATH_INT`. The existing org-level `SSH_PRIVATE_KEY` is reused, so its public half must be authorized for `DEPLOY_USER_INT` on the int server.

`DEPLOY_PATH_INT` must be byte-identical to `UI_DIST_PATH` in the int server's `backend/.env`, because `docker-compose.yml` mounts `${UI_DIST_PATH}:${UI_DIST_PATH}` into the api container. If they diverge, CI goes green while the API serves a stale UI.

## Out of scope

`catserver.yml` is deliberately untouched. Its target server is compiled in, not configured: `catserver/src/args.rs` picks between two hardcoded DNS names off a boolean `--dev-server` switch, and `wix/main.wxs` bakes that flag into the Windows shortcut. Pointing an installer at int needs a Rust change and belongs in its own ticket.

## First run after merging dev into int

`ui.yml` does a real deploy. `backend.yml` is a no-op that still validates SSH and the secrets: `deploy.sh` diffs changed files relative to `backend/`, and only workflow files changed, so it exits early with "No files changed in backend/".

Note the `int` branch was fast-forwarded to `dev` before this, so it carries 281 commits of backend changes including Alembic migrations. The first *real* backend deploy to int will run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub9sqF8LZR9SQETf25fSiz