### PR TITLE
catserver: target the server by hostname, and publish to int

### DIFF
--- a/.github/workflows/catserver.yml
+++ b/.github/workflows/catserver.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/catserver.yml"
     branches:
       - "dev"
+      - "int"
     tags:
       - "catserver-v*"
   pull_request:
@@ -15,6 +16,7 @@ on:
       - ".github/workflows/catserver.yml"
     branches:
       - "dev"
+      - "int"
 
 env:
   CARGO_TARGET_DIR: target
@@ -48,7 +50,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup SSH
-        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/int' || startsWith(github.ref, 'refs/tags/')
         run: |
           export HOME=/root
           mkdir -p $HOME/.ssh
@@ -56,6 +58,7 @@ jobs:
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > $HOME/.ssh/id_rsa
           chmod 600 $HOME/.ssh/id_rsa
           ssh-keyscan -H "${{ secrets.DEPLOY_HOST_DEV }}" >> $HOME/.ssh/known_hosts
+          ssh-keyscan -H "${{ secrets.DEPLOY_HOST_INT }}" >> $HOME/.ssh/known_hosts
           ssh-keyscan -H "${{ secrets.DEPLOY_HOST_PROD }}" >> $HOME/.ssh/known_hosts
           chmod 644 $HOME/.ssh/known_hosts
 
@@ -143,16 +146,16 @@ jobs:
           done
 
       - name: Change build artifacts ownership
-        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/int' || startsWith(github.ref, 'refs/tags/')
         working-directory: ./catserver
         run: chown -R wix:wix target
 
       - name: Build installer
-        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/int' || startsWith(github.ref, 'refs/tags/')
         working-directory: ./catserver
         run: su wix -c "./build_msi.sh in-docker --default-shortcut-arguments '${DEFAULT_SHORTCUT_ARGUMENTS}'"
         env:
-          DEFAULT_SHORTCUT_ARGUMENTS: ${{ github.ref == 'refs/heads/dev' && '--dev-server' || '' }}
+          DEFAULT_SHORTCUT_ARGUMENTS: ${{ github.ref == 'refs/heads/dev' && '--dev-server' || github.ref == 'refs/heads/int' && '--server holycluster-int.iarc.org' || '' }}
 
       - name: Upload to Development Server
         if: github.ref == 'refs/heads/dev'
@@ -161,6 +164,18 @@ jobs:
           python3 catserver/publish.py \
             --deploy-user ${{ secrets.DEPLOY_USER_DEV }} \
             --deploy-host ${{ secrets.DEPLOY_HOST_DEV }} \
+            --remote-artifact-dir /opt/msi \
+            --version "$VERSION" \
+            --artifact "windows:x86_64:catserver/target/$TARGET/release/HolyCluster.msi:$VERSION-windows-x86_64.msi" \
+            --artifact "linux:x86_64:catserver/target/x86_64-unknown-linux-gnu/release/$VERSION-linux-x86_64.AppImage:$VERSION-linux-x86_64.AppImage"
+
+      - name: Upload to Integration Server
+        if: github.ref == 'refs/heads/int'
+        run: |
+          VERSION="$(git describe --match 'catserver-v*')"
+          python3 catserver/publish.py \
+            --deploy-user ${{ secrets.DEPLOY_USER_INT }} \
+            --deploy-host ${{ secrets.DEPLOY_HOST_INT }} \
             --remote-artifact-dir /opt/msi \
             --version "$VERSION" \
             --artifact "windows:x86_64:catserver/target/$TARGET/release/HolyCluster.msi:$VERSION-windows-x86_64.msi" \

--- a/catserver/src/args.rs
+++ b/catserver/src/args.rs
@@ -7,12 +7,17 @@ use crate::server::ServerConfig;
 pub const BASE_LOCAL_PORT: u16 = 3000;
 pub const DEFAULT_RIGCTLD_HOST: &str = "127.0.0.1";
 pub const DEFAULT_RIGCTLD_PORT: u16 = 4532;
+pub const PROD_SERVER: &str = "holycluster.iarc.org";
+pub const DEV_SERVER: &str = "holycluster-dev.iarc.org";
 
 #[derive(FromArgs)]
 /// The Holy Cluster - debug flags
 #[argh(help_triggers("-h", "--help"))]
 pub struct Args {
-    /// use the development HolyCluster server
+    /// hostname of the HolyCluster server to use, e.g. holycluster-int.iarc.org
+    #[argh(option)]
+    pub server: Option<String>,
+    /// use the development HolyCluster server (deprecated, use --server)
     #[argh(switch)]
     pub dev_server: bool,
     /// run with dummy radio instead of real radio
@@ -43,10 +48,12 @@ pub struct Args {
 
 pub fn server_config(args: &Args) -> ServerConfig {
     let local_port = args.port.unwrap_or(BASE_LOCAL_PORT);
-    let dns = if args.dev_server {
-        "holycluster-dev.iarc.org"
-    } else {
-        "holycluster.iarc.org"
+    // --server wins over the deprecated --dev-server switch, so an explicit
+    // host always beats a shortcut that still carries the old flag.
+    let dns = match args.server.as_deref() {
+        Some(server) => server,
+        None if args.dev_server => DEV_SERVER,
+        None => PROD_SERVER,
     };
     ServerConfig {
         dns: dns.into(),
@@ -62,4 +69,40 @@ pub fn rigctld_endpoint(args: &Args) -> (String, u16) {
             .unwrap_or_else(|| DEFAULT_RIGCTLD_HOST.into()),
         args.rigctld_port.unwrap_or(DEFAULT_RIGCTLD_PORT),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dns_for(args: &[&str]) -> String {
+        let args = Args::from_args(&["catserver"], args).expect("args should parse");
+        server_config(&args).dns
+    }
+
+    #[test]
+    fn defaults_to_the_production_server() {
+        assert_eq!(dns_for(&[]), PROD_SERVER);
+    }
+
+    #[test]
+    fn dev_server_switch_still_selects_the_dev_server() {
+        assert_eq!(dns_for(&["--dev-server"]), DEV_SERVER);
+    }
+
+    #[test]
+    fn server_option_selects_an_arbitrary_host() {
+        assert_eq!(
+            dns_for(&["--server", "holycluster-int.iarc.org"]),
+            "holycluster-int.iarc.org"
+        );
+    }
+
+    #[test]
+    fn server_option_overrides_the_dev_server_switch() {
+        assert_eq!(
+            dns_for(&["--dev-server", "--server", "holycluster-int.iarc.org"]),
+            "holycluster-int.iarc.org"
+        );
+    }
 }


### PR DESCRIPTION
Closes #396.

## Why

`backend.yml` and `ui.yml` deploy to int since #395, but catserver could not follow. Its target server was **compiled in**: `args.rs` chose between two hardcoded DNS names off a `--dev-server` boolean, so no installer could point at `holycluster-int.iarc.org` without a code change, and a fourth environment would have hit the same wall.

## What

**`catserver/src/args.rs`** — replaces the boolean with `--server <dns>`:

```rust
let dns = match args.server.as_deref() {
    Some(server) => server,
    None if args.dev_server => DEV_SERVER,
    None => PROD_SERVER,
};
```

`--dev-server` is **kept as a deprecated alias**, deliberately. `wix/main.wxs` bakes `--dev-server` into the "HolyCluster (Dev Server)" shortcut, and already-installed shortcuts must keep working. `--server` wins when both are passed, so a shortcut carrying the old flag can still be overridden.

Hardcoded hostnames become `PROD_SERVER` / `DEV_SERVER` consts.

**`.github/workflows/catserver.yml`** — adds `int` to triggers and guards, adds `DEPLOY_HOST_INT` to `ssh-keyscan`, adds an `Upload to Integration Server` step mirroring dev/prod, and extends the shortcut-arguments expression:

```
${{ github.ref == 'refs/heads/dev' && '--dev-server'
 || github.ref == 'refs/heads/int' && '--server holycluster-int.iarc.org'
 || '' }}
```

## Tests

`server_config` had no tests. Added four covering the default, the deprecated switch, the new option, and the precedence between them.

## Not changed

**`wix/main.wxs` needs no edit**, contrary to what #396 assumed. The main shortcut already takes `$(var.DefaultShortcutArguments)` from `build_msi.sh`, so int only needs a different string passed in. The one hardcoded `--dev-server` shortcut keeps working via the retained alias.

`Cargo.toml` stays at `0.1.0`; the real version comes from `git describe --match 'catserver-v*'` at build time.

## Verification note

I could not run `cargo test` locally: `application.rs:61` calls `tray_icon::run_tray_icon`, which is `#[cfg(windows)]`, so the crate does not compile on macOS. That break is pre-existing and unrelated to this change. `cargo fmt --check` passes locally; the Linux test run in CI is the real check on these tests.

## Prod behaviour

Unchanged. Prod still ships on tags, and with neither flag the default is still `holycluster.iarc.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub9sqF8LZR9SQETf25fSiz