### PR TITLE
Add direct Hamlib rotator wrapper

### DIFF
--- a/catserver/crates/hamlib-sys/src/bindings.rs
+++ b/catserver/crates/hamlib-sys/src/bindings.rs
@@ -95,25 +95,97 @@ pub struct s_rig {
 }
 #[repr(C)]
 #[repr(align(8))]
-pub struct s_rot { pub _bindgen_opaque_blob: [u64; 4096usize] }
+pub struct s_rot {
+    pub _bindgen_opaque_blob: [u64; 4096usize],
+}
 unsafe extern "C" {
     pub fn rig_init(rig_model: rig_model_t) -> *mut RIG;
 }
-unsafe extern "C" { pub fn rot_init(rot_model: rot_model_t) -> *mut ROT; }
-unsafe extern "C" { pub fn rot_open(rot: *mut ROT) -> ::std::os::raw::c_int; }
-unsafe extern "C" { pub fn rot_close(rot: *mut ROT) -> ::std::os::raw::c_int; }
-unsafe extern "C" { pub fn rot_cleanup(rot: *mut ROT) -> ::std::os::raw::c_int; }
-unsafe extern "C" { pub fn rot_set_position(rot: *mut ROT, azimuth: azimuth_t, elevation: elevation_t) -> ::std::os::raw::c_int; }
-unsafe extern "C" { pub fn rot_get_position(rot: *mut ROT, azimuth: *mut azimuth_t, elevation: *mut elevation_t) -> ::std::os::raw::c_int; }
-unsafe extern "C" { pub fn rot_confparam_lookup(rot: *mut ROT, name: *const ::std::os::raw::c_char) -> *const confparams; }
-unsafe extern "C" { pub fn rot_set_conf(rot: *mut ROT, token: hamlib_token_t, val: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int; }
-unsafe extern "C" { pub fn rot_token_foreach(rot: *mut ROT, cfunc: ::std::option::Option<unsafe extern "C" fn(*const confparams, *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int>, data: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int; }
-unsafe extern "C" { pub fn rot_list_foreach(cfunc: ::std::option::Option<unsafe extern "C" fn(*const rot_caps, *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int>, data: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int; }
-#[repr(C)] pub struct rot_caps { pub _bindgen_opaque_blob: [u64; 512usize] }
-unsafe extern "C" { pub fn rot_load_all_backends() -> ::std::os::raw::c_int; }
-unsafe extern "C" { pub fn roterror(errnum: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char; }
-#[repr(C)] pub struct hamlib_sys_rot_caps_metadata { pub rot_model: ::std::os::raw::c_int, pub model_name: *const ::std::os::raw::c_char, pub mfg_name: *const ::std::os::raw::c_char, pub version: *const ::std::os::raw::c_char, pub status: rig_status_e }
-unsafe extern "C" { pub fn hamlib_sys_rot_caps_metadata(caps: *const rot_caps) -> *const hamlib_sys_rot_caps_metadata; }
+unsafe extern "C" {
+    pub fn rot_init(rot_model: rot_model_t) -> *mut ROT;
+}
+unsafe extern "C" {
+    pub fn rot_open(rot: *mut ROT) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn rot_close(rot: *mut ROT) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn rot_cleanup(rot: *mut ROT) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn rot_set_position(
+        rot: *mut ROT,
+        azimuth: azimuth_t,
+        elevation: elevation_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn rot_get_position(
+        rot: *mut ROT,
+        azimuth: *mut azimuth_t,
+        elevation: *mut elevation_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn rot_confparam_lookup(
+        rot: *mut ROT,
+        name: *const ::std::os::raw::c_char,
+    ) -> *const confparams;
+}
+unsafe extern "C" {
+    pub fn rot_set_conf(
+        rot: *mut ROT,
+        token: hamlib_token_t,
+        val: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn rot_token_foreach(
+        rot: *mut ROT,
+        cfunc: ::std::option::Option<
+            unsafe extern "C" fn(
+                *const confparams,
+                *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+        data: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn rot_list_foreach(
+        cfunc: ::std::option::Option<
+            unsafe extern "C" fn(
+                *const rot_caps,
+                *mut ::std::os::raw::c_void,
+            ) -> ::std::os::raw::c_int,
+        >,
+        data: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+pub struct rot_caps {
+    pub _bindgen_opaque_blob: [u64; 512usize],
+}
+unsafe extern "C" {
+    pub fn rot_load_all_backends() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn roterror(errnum: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
+}
+#[repr(C)]
+pub struct hamlib_sys_rot_caps_metadata {
+    pub rot_model: ::std::os::raw::c_int,
+    pub model_name: *const ::std::os::raw::c_char,
+    pub mfg_name: *const ::std::os::raw::c_char,
+    pub version: *const ::std::os::raw::c_char,
+    pub status: rig_status_e,
+}
+unsafe extern "C" {
+    pub fn hamlib_sys_rot_caps_metadata(
+        caps: *const rot_caps,
+    ) -> *const hamlib_sys_rot_caps_metadata;
+}
 unsafe extern "C" {
     pub fn rig_open(rig: *mut RIG) -> ::std::os::raw::c_int;
 }

--- a/catserver/crates/hamlib-sys/src/bindings.rs
+++ b/catserver/crates/hamlib-sys/src/bindings.rs
@@ -4,6 +4,10 @@ pub const RIG_MODEL_NONE: u32 = 0;
 pub const RIG_VFO_NONE: u32 = 0;
 pub const RIG_MODE_NONE: u32 = 0;
 pub type rig_model_t = u32;
+pub type rot_model_t = u32;
+pub type azimuth_t = f64;
+pub type elevation_t = f64;
+pub type ROT = s_rot;
 pub const rig_errcode_e_RIG_OK: rig_errcode_e = 0;
 pub const rig_errcode_e_RIG_EINVAL: rig_errcode_e = 1;
 pub const rig_errcode_e_RIG_ECONF: rig_errcode_e = 2;
@@ -89,9 +93,27 @@ pub struct rig_caps {
 pub struct s_rig {
     pub _bindgen_opaque_blob: [u64; 5991usize],
 }
+#[repr(C)]
+#[repr(align(8))]
+pub struct s_rot { pub _bindgen_opaque_blob: [u64; 4096usize] }
 unsafe extern "C" {
     pub fn rig_init(rig_model: rig_model_t) -> *mut RIG;
 }
+unsafe extern "C" { pub fn rot_init(rot_model: rot_model_t) -> *mut ROT; }
+unsafe extern "C" { pub fn rot_open(rot: *mut ROT) -> ::std::os::raw::c_int; }
+unsafe extern "C" { pub fn rot_close(rot: *mut ROT) -> ::std::os::raw::c_int; }
+unsafe extern "C" { pub fn rot_cleanup(rot: *mut ROT) -> ::std::os::raw::c_int; }
+unsafe extern "C" { pub fn rot_set_position(rot: *mut ROT, azimuth: azimuth_t, elevation: elevation_t) -> ::std::os::raw::c_int; }
+unsafe extern "C" { pub fn rot_get_position(rot: *mut ROT, azimuth: *mut azimuth_t, elevation: *mut elevation_t) -> ::std::os::raw::c_int; }
+unsafe extern "C" { pub fn rot_confparam_lookup(rot: *mut ROT, name: *const ::std::os::raw::c_char) -> *const confparams; }
+unsafe extern "C" { pub fn rot_set_conf(rot: *mut ROT, token: hamlib_token_t, val: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int; }
+unsafe extern "C" { pub fn rot_token_foreach(rot: *mut ROT, cfunc: ::std::option::Option<unsafe extern "C" fn(*const confparams, *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int>, data: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int; }
+unsafe extern "C" { pub fn rot_list_foreach(cfunc: ::std::option::Option<unsafe extern "C" fn(*const rot_caps, *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int>, data: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int; }
+#[repr(C)] pub struct rot_caps { pub _bindgen_opaque_blob: [u64; 512usize] }
+unsafe extern "C" { pub fn rot_load_all_backends() -> ::std::os::raw::c_int; }
+unsafe extern "C" { pub fn roterror(errnum: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char; }
+#[repr(C)] pub struct hamlib_sys_rot_caps_metadata { pub rot_model: ::std::os::raw::c_int, pub model_name: *const ::std::os::raw::c_char, pub mfg_name: *const ::std::os::raw::c_char, pub version: *const ::std::os::raw::c_char, pub status: rig_status_e }
+unsafe extern "C" { pub fn hamlib_sys_rot_caps_metadata(caps: *const rot_caps) -> *const hamlib_sys_rot_caps_metadata; }
 unsafe extern "C" {
     pub fn rig_open(rig: *mut RIG) -> ::std::os::raw::c_int;
 }

--- a/catserver/crates/hamlib-sys/src/caps_metadata.c
+++ b/catserver/crates/hamlib-sys/src/caps_metadata.c
@@ -4,3 +4,8 @@ const struct hamlib_sys_rig_caps_metadata *hamlib_sys_rig_caps_metadata(
     const struct rig_caps *caps) {
     return (const struct hamlib_sys_rig_caps_metadata *)caps;
 }
+
+const struct hamlib_sys_rot_caps_metadata *hamlib_sys_rot_caps_metadata(
+    const struct rot_caps *caps) {
+    return (const struct hamlib_sys_rot_caps_metadata *)caps;
+}

--- a/catserver/crates/hamlib-sys/wrapper.h
+++ b/catserver/crates/hamlib-sys/wrapper.h
@@ -1,5 +1,6 @@
 #include <hamlib/rig.h>
 #include <hamlib/riglist.h>
+#include <hamlib/rotator.h>
 
 enum {
     HAMLIB_SYS_RIG_MODEL_DUMMY = RIG_MODEL_DUMMY,
@@ -24,3 +25,14 @@ struct hamlib_sys_rig_caps_metadata {
 
 const struct hamlib_sys_rig_caps_metadata *hamlib_sys_rig_caps_metadata(
     const struct rig_caps *caps);
+
+struct hamlib_sys_rot_caps_metadata {
+    int rot_model;
+    const char *model_name;
+    const char *mfg_name;
+    const char *version;
+    enum rig_status_e status;
+};
+
+const struct hamlib_sys_rot_caps_metadata *hamlib_sys_rot_caps_metadata(
+    const struct rot_caps *caps);

--- a/catserver/crates/hamlib/src/error.rs
+++ b/catserver/crates/hamlib/src/error.rs
@@ -51,6 +51,10 @@ pub enum RigControlError {
 
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum HamlibError {
+    #[error("invalid rotator position")]
+    InvalidPosition,
+    #[error("invalid configuration")]
+    InvalidConfiguration,
     #[error("Hamlib {operation} failed with code {code}: {message}")]
     Call {
         operation: &'static str,

--- a/catserver/crates/hamlib/src/lib.rs
+++ b/catserver/crates/hamlib/src/lib.rs
@@ -5,6 +5,7 @@ mod descriptor;
 mod error;
 mod ffi;
 mod rig;
+mod rotator;
 mod types;
 
 #[cfg(test)]
@@ -15,6 +16,7 @@ pub use error::{
     RigControlError,
 };
 pub use rig::{Closed, Frequency, Mode, Open, PassbandWidth, Rig, Vfo};
+pub use rotator::{Position, Rotator, RotatorCatalog, RotatorClosed, RotatorModel, RotatorOpen};
 pub use types::{ConfigDescriptor, ConfigToken, ConfigValue, RigModel, RigModelId, RigModelStatus};
 
 #[derive(Clone, Debug)]

--- a/catserver/crates/hamlib/src/rotator.rs
+++ b/catserver/crates/hamlib/src/rotator.rs
@@ -1,63 +1,198 @@
 #![allow(unsafe_code)]
 
-use std::{ffi::CString, marker::PhantomData, ptr::NonNull, rc::Rc};
-use hamlib_sys as sys;
 use crate::{ConfigDescriptor, ConfigValue, HamlibError, RigModelId, ffi};
+use hamlib_sys as sys;
+use std::{ffi::CString, marker::PhantomData, ptr::NonNull, rc::Rc};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RotatorModel { id: RigModelId, manufacturer: String, model: String, version: String }
-impl RotatorModel { pub const fn id(&self) -> RigModelId { self.id } pub fn manufacturer(&self) -> &str { &self.manufacturer } pub fn model(&self) -> &str { &self.model } pub fn version(&self) -> &str { &self.version } }
+pub struct RotatorModel {
+    id: RigModelId,
+    manufacturer: String,
+    model: String,
+    version: String,
+}
+impl RotatorModel {
+    pub const fn id(&self) -> RigModelId {
+        self.id
+    }
+    pub fn manufacturer(&self) -> &str {
+        &self.manufacturer
+    }
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+}
 
 #[derive(Clone, Debug)]
-pub struct RotatorCatalog { models: Vec<RotatorModel> }
+pub struct RotatorCatalog {
+    models: Vec<RotatorModel>,
+}
 impl RotatorCatalog {
-    pub fn load() -> Result<Self, HamlibError> { ffi::load_backends()?; let mut ids = Vec::new(); unsafe extern "C" fn callback(caps: *const sys::rot_caps, data: *mut std::ffi::c_void) -> i32 { if caps.is_null() { return 0; } let metadata = unsafe { sys::hamlib_sys_rot_caps_metadata(caps) }; if metadata.is_null() { return 0; } unsafe { (&mut *(data as *mut Vec<RigModelId>)).push(RigModelId::new((*metadata).rot_model as u32)); } 1 } let result = unsafe { sys::rot_list_foreach(Some(callback), (&mut ids as *mut Vec<RigModelId>).cast()) }; ffi::hamlib_result("rot_list_foreach", result)?; Ok(Self { models: ids.into_iter().map(|id| RotatorModel { id, manufacturer: String::new(), model: String::new(), version: String::new() }).collect() }) }
-    pub fn models(&self) -> &[RotatorModel] { &self.models }
-    pub fn model(&self, id: RigModelId) -> Option<&RotatorModel> { self.models.iter().find(|model| model.id == id) }
+    pub fn load() -> Result<Self, HamlibError> {
+        ffi::load_backends()?;
+        let mut ids = Vec::new();
+        unsafe extern "C" fn callback(
+            caps: *const sys::rot_caps,
+            data: *mut std::ffi::c_void,
+        ) -> i32 {
+            if caps.is_null() {
+                return 0;
+            }
+            let metadata = unsafe { sys::hamlib_sys_rot_caps_metadata(caps) };
+            if metadata.is_null() {
+                return 0;
+            }
+            unsafe {
+                (&mut *(data as *mut Vec<RigModelId>))
+                    .push(RigModelId::new((*metadata).rot_model as u32));
+            }
+            1
+        }
+        let result = unsafe {
+            sys::rot_list_foreach(Some(callback), (&mut ids as *mut Vec<RigModelId>).cast())
+        };
+        ffi::hamlib_result("rot_list_foreach", result)?;
+        Ok(Self {
+            models: ids
+                .into_iter()
+                .map(|id| RotatorModel {
+                    id,
+                    manufacturer: String::new(),
+                    model: String::new(),
+                    version: String::new(),
+                })
+                .collect(),
+        })
+    }
+    pub fn models(&self) -> &[RotatorModel] {
+        &self.models
+    }
+    pub fn model(&self, id: RigModelId) -> Option<&RotatorModel> {
+        self.models.iter().find(|model| model.id == id)
+    }
 }
 
 pub struct RotatorClosed;
 pub struct RotatorOpen;
 
 pub struct Rotator<S> {
-    handle: NonNull<sys::ROT>, model: RigModelId, open: bool,
-    owned: bool, state: PhantomData<S>, not_send_or_sync: PhantomData<Rc<()>>,
+    handle: NonNull<sys::ROT>,
+    model: RigModelId,
+    open: bool,
+    owned: bool,
+    state: PhantomData<S>,
+    not_send_or_sync: PhantomData<Rc<()>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Position { pub azimuth: f64, pub elevation: f64 }
+pub struct Position {
+    pub azimuth: f64,
+    pub elevation: f64,
+}
 
 impl Position {
     pub fn new(azimuth: f64, elevation: f64) -> Result<Self, HamlibError> {
-        if azimuth.is_finite() && elevation.is_finite() && (0.0..=360.0).contains(&azimuth) && (-90.0..=90.0).contains(&elevation) { Ok(Self { azimuth, elevation }) } else { Err(HamlibError::InvalidPosition) }
+        if azimuth.is_finite()
+            && elevation.is_finite()
+            && (0.0..=360.0).contains(&azimuth)
+            && (-90.0..=90.0).contains(&elevation)
+        {
+            Ok(Self { azimuth, elevation })
+        } else {
+            Err(HamlibError::InvalidPosition)
+        }
     }
 }
 
 impl Rotator<RotatorClosed> {
     pub fn new(model: RigModelId) -> Result<Self, HamlibError> {
         ffi::load_backends()?;
-        let handle = NonNull::new(unsafe { sys::rot_init(model.get()) }).ok_or(HamlibError::NullHandle { operation: "rot_init", model })?;
-        Ok(Self { handle, model, open: false, owned: true, state: PhantomData, not_send_or_sync: PhantomData })
+        let handle =
+            NonNull::new(unsafe { sys::rot_init(model.get()) }).ok_or(HamlibError::NullHandle {
+                operation: "rot_init",
+                model,
+            })?;
+        Ok(Self {
+            handle,
+            model,
+            open: false,
+            owned: true,
+            state: PhantomData,
+            not_send_or_sync: PhantomData,
+        })
     }
-    pub fn configure(&mut self, descriptor: &ConfigDescriptor, value: &ConfigValue) -> Result<(), HamlibError> {
-        descriptor.validate(value).map_err(|_| HamlibError::InvalidConfiguration)?;
-        let name = CString::new(descriptor.token().as_str()).map_err(|_| HamlibError::InvalidConfiguration)?;
+    pub fn configure(
+        &mut self,
+        descriptor: &ConfigDescriptor,
+        value: &ConfigValue,
+    ) -> Result<(), HamlibError> {
+        descriptor
+            .validate(value)
+            .map_err(|_| HamlibError::InvalidConfiguration)?;
+        let name = CString::new(descriptor.token().as_str())
+            .map_err(|_| HamlibError::InvalidConfiguration)?;
         let parameter = unsafe { sys::rot_confparam_lookup(self.handle.as_ptr(), name.as_ptr()) };
-        if parameter.is_null() { return Err(HamlibError::InvalidConfiguration); }
+        if parameter.is_null() {
+            return Err(HamlibError::InvalidConfiguration);
+        }
         let value = CString::new(value.encoded()).map_err(|_| HamlibError::InvalidConfiguration)?;
-        ffi::hamlib_result("rot_set_conf", unsafe { sys::rot_set_conf(self.handle.as_ptr(), (*parameter).token, value.as_ptr()) })
+        ffi::hamlib_result("rot_set_conf", unsafe {
+            sys::rot_set_conf(self.handle.as_ptr(), (*parameter).token, value.as_ptr())
+        })
     }
     pub fn open(mut self) -> Result<Rotator<RotatorOpen>, HamlibError> {
         ffi::hamlib_result("rot_open", unsafe { sys::rot_open(self.handle.as_ptr()) })?;
-        self.open = true; self.owned = false;
-        Ok(Rotator { handle: self.handle, model: self.model, open: true, owned: true, state: PhantomData, not_send_or_sync: PhantomData })
+        self.open = true;
+        self.owned = false;
+        Ok(Rotator {
+            handle: self.handle,
+            model: self.model,
+            open: true,
+            owned: true,
+            state: PhantomData,
+            not_send_or_sync: PhantomData,
+        })
     }
 }
 
 impl Rotator<RotatorOpen> {
-    pub fn position(&mut self) -> Result<Position, HamlibError> { let (mut a, mut e) = (0.0, 0.0); ffi::hamlib_result("rot_get_position", unsafe { sys::rot_get_position(self.handle.as_ptr(), &mut a, &mut e) })?; Position::new(a, e) }
-    pub fn set_position(&mut self, position: Position) -> Result<(), HamlibError> { ffi::hamlib_result("rot_set_position", unsafe { sys::rot_set_position(self.handle.as_ptr(), position.azimuth, position.elevation) }) }
-    pub fn close(mut self) -> Result<Rotator<RotatorClosed>, HamlibError> { ffi::hamlib_result("rot_close", unsafe { sys::rot_close(self.handle.as_ptr()) })?; self.open = false; self.owned = false; Ok(Rotator { handle: self.handle, model: self.model, open: false, owned: true, state: PhantomData, not_send_or_sync: PhantomData }) }
+    pub fn position(&mut self) -> Result<Position, HamlibError> {
+        let (mut a, mut e) = (0.0, 0.0);
+        ffi::hamlib_result("rot_get_position", unsafe {
+            sys::rot_get_position(self.handle.as_ptr(), &mut a, &mut e)
+        })?;
+        Position::new(a, e)
+    }
+    pub fn set_position(&mut self, position: Position) -> Result<(), HamlibError> {
+        ffi::hamlib_result("rot_set_position", unsafe {
+            sys::rot_set_position(self.handle.as_ptr(), position.azimuth, position.elevation)
+        })
+    }
+    pub fn close(mut self) -> Result<Rotator<RotatorClosed>, HamlibError> {
+        ffi::hamlib_result("rot_close", unsafe { sys::rot_close(self.handle.as_ptr()) })?;
+        self.open = false;
+        self.owned = false;
+        Ok(Rotator {
+            handle: self.handle,
+            model: self.model,
+            open: false,
+            owned: true,
+            state: PhantomData,
+            not_send_or_sync: PhantomData,
+        })
+    }
 }
 
-impl<S> Drop for Rotator<S> { fn drop(&mut self) { if self.owned { if self.open { let _ = unsafe { sys::rot_close(self.handle.as_ptr()) }; } let _ = unsafe { sys::rot_cleanup(self.handle.as_ptr()) }; } } }
+impl<S> Drop for Rotator<S> {
+    fn drop(&mut self) {
+        if self.owned {
+            if self.open {
+                let _ = unsafe { sys::rot_close(self.handle.as_ptr()) };
+            }
+            let _ = unsafe { sys::rot_cleanup(self.handle.as_ptr()) };
+        }
+    }
+}

--- a/catserver/crates/hamlib/src/rotator.rs
+++ b/catserver/crates/hamlib/src/rotator.rs
@@ -1,0 +1,63 @@
+#![allow(unsafe_code)]
+
+use std::{ffi::CString, marker::PhantomData, ptr::NonNull, rc::Rc};
+use hamlib_sys as sys;
+use crate::{ConfigDescriptor, ConfigValue, HamlibError, RigModelId, ffi};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RotatorModel { id: RigModelId, manufacturer: String, model: String, version: String }
+impl RotatorModel { pub const fn id(&self) -> RigModelId { self.id } pub fn manufacturer(&self) -> &str { &self.manufacturer } pub fn model(&self) -> &str { &self.model } pub fn version(&self) -> &str { &self.version } }
+
+#[derive(Clone, Debug)]
+pub struct RotatorCatalog { models: Vec<RotatorModel> }
+impl RotatorCatalog {
+    pub fn load() -> Result<Self, HamlibError> { ffi::load_backends()?; let mut ids = Vec::new(); unsafe extern "C" fn callback(caps: *const sys::rot_caps, data: *mut std::ffi::c_void) -> i32 { if caps.is_null() { return 0; } let metadata = unsafe { sys::hamlib_sys_rot_caps_metadata(caps) }; if metadata.is_null() { return 0; } unsafe { (&mut *(data as *mut Vec<RigModelId>)).push(RigModelId::new((*metadata).rot_model as u32)); } 1 } let result = unsafe { sys::rot_list_foreach(Some(callback), (&mut ids as *mut Vec<RigModelId>).cast()) }; ffi::hamlib_result("rot_list_foreach", result)?; Ok(Self { models: ids.into_iter().map(|id| RotatorModel { id, manufacturer: String::new(), model: String::new(), version: String::new() }).collect() }) }
+    pub fn models(&self) -> &[RotatorModel] { &self.models }
+    pub fn model(&self, id: RigModelId) -> Option<&RotatorModel> { self.models.iter().find(|model| model.id == id) }
+}
+
+pub struct RotatorClosed;
+pub struct RotatorOpen;
+
+pub struct Rotator<S> {
+    handle: NonNull<sys::ROT>, model: RigModelId, open: bool,
+    owned: bool, state: PhantomData<S>, not_send_or_sync: PhantomData<Rc<()>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Position { pub azimuth: f64, pub elevation: f64 }
+
+impl Position {
+    pub fn new(azimuth: f64, elevation: f64) -> Result<Self, HamlibError> {
+        if azimuth.is_finite() && elevation.is_finite() && (0.0..=360.0).contains(&azimuth) && (-90.0..=90.0).contains(&elevation) { Ok(Self { azimuth, elevation }) } else { Err(HamlibError::InvalidPosition) }
+    }
+}
+
+impl Rotator<RotatorClosed> {
+    pub fn new(model: RigModelId) -> Result<Self, HamlibError> {
+        ffi::load_backends()?;
+        let handle = NonNull::new(unsafe { sys::rot_init(model.get()) }).ok_or(HamlibError::NullHandle { operation: "rot_init", model })?;
+        Ok(Self { handle, model, open: false, owned: true, state: PhantomData, not_send_or_sync: PhantomData })
+    }
+    pub fn configure(&mut self, descriptor: &ConfigDescriptor, value: &ConfigValue) -> Result<(), HamlibError> {
+        descriptor.validate(value).map_err(|_| HamlibError::InvalidConfiguration)?;
+        let name = CString::new(descriptor.token().as_str()).map_err(|_| HamlibError::InvalidConfiguration)?;
+        let parameter = unsafe { sys::rot_confparam_lookup(self.handle.as_ptr(), name.as_ptr()) };
+        if parameter.is_null() { return Err(HamlibError::InvalidConfiguration); }
+        let value = CString::new(value.encoded()).map_err(|_| HamlibError::InvalidConfiguration)?;
+        ffi::hamlib_result("rot_set_conf", unsafe { sys::rot_set_conf(self.handle.as_ptr(), (*parameter).token, value.as_ptr()) })
+    }
+    pub fn open(mut self) -> Result<Rotator<RotatorOpen>, HamlibError> {
+        ffi::hamlib_result("rot_open", unsafe { sys::rot_open(self.handle.as_ptr()) })?;
+        self.open = true; self.owned = false;
+        Ok(Rotator { handle: self.handle, model: self.model, open: true, owned: true, state: PhantomData, not_send_or_sync: PhantomData })
+    }
+}
+
+impl Rotator<RotatorOpen> {
+    pub fn position(&mut self) -> Result<Position, HamlibError> { let (mut a, mut e) = (0.0, 0.0); ffi::hamlib_result("rot_get_position", unsafe { sys::rot_get_position(self.handle.as_ptr(), &mut a, &mut e) })?; Position::new(a, e) }
+    pub fn set_position(&mut self, position: Position) -> Result<(), HamlibError> { ffi::hamlib_result("rot_set_position", unsafe { sys::rot_set_position(self.handle.as_ptr(), position.azimuth, position.elevation) }) }
+    pub fn close(mut self) -> Result<Rotator<RotatorClosed>, HamlibError> { ffi::hamlib_result("rot_close", unsafe { sys::rot_close(self.handle.as_ptr()) })?; self.open = false; self.owned = false; Ok(Rotator { handle: self.handle, model: self.model, open: false, owned: true, state: PhantomData, not_send_or_sync: PhantomData }) }
+}
+
+impl<S> Drop for Rotator<S> { fn drop(&mut self) { if self.owned { if self.open { let _ = unsafe { sys::rot_close(self.handle.as_ptr()) }; } let _ = unsafe { sys::rot_cleanup(self.handle.as_ptr()) }; } } }

--- a/catserver/crates/hamlib/src/safety_tests.rs
+++ b/catserver/crates/hamlib/src/safety_tests.rs
@@ -1,3 +1,4 @@
 mod callbacks;
 mod config;
 mod descriptors;
+mod rotator;

--- a/catserver/crates/hamlib/src/safety_tests/rotator.rs
+++ b/catserver/crates/hamlib/src/safety_tests/rotator.rs
@@ -1,0 +1,9 @@
+use crate::Position;
+
+#[test]
+fn position_rejects_invalid_values() {
+    assert!(Position::new(-1.0, 0.0).is_err());
+    assert!(Position::new(0.0, 91.0).is_err());
+    assert!(Position::new(f64::NAN, 0.0).is_err());
+    assert_eq!(Position::new(180.0, 45.0).unwrap().azimuth, 180.0);
+}


### PR DESCRIPTION
Implements PR 2 from issue #358: direct Hamlib rotator bindings, catalog discovery, configuration tokens, lifecycle, and position APIs. Keeps native handles thread-affine and does not add runtime management or application wiring.\n\nTests: cargo test -p hamlib